### PR TITLE
hotfix: replace stream session ended

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ To set your Product Advertising API credentials you must:
 
 After deployment, through [Amazon OneLink](https://affiliate-program.amazon.com/resource-center/onelink-launch), you can best earn money via product affiliate links by redirecting international traffic to the appropriate Amazon store for their location, increasing the likelihood that they will make a purchase. To get started:
 
-1. Sign up for Amazon Associates: To use Amazon OneLink, you need to be an [Amazon Associate](https://associates.amazon.ca/). If you're not already signed up, go to the Amazon Associates website and create an account.
+1. Sign up for Amazon Associates: To use Amazon OneLink, you need to be an [Amazon Associate](https://affiliate-program.amazon.com/). If you're not already signed up, go to the Amazon Associates website and create an account.
 
 2. Enable OneLink: Once you've signed up for Amazon Associates, navigate to the 'Manage Tracking IDs' section located at the top right-hand corner
    of the Amazon Associates portal.

--- a/cdk/lib/ChannelsStack/Constructs/ChannelsCognitoTriggers.ts
+++ b/cdk/lib/ChannelsStack/Constructs/ChannelsCognitoTriggers.ts
@@ -3,9 +3,11 @@ import { Construct } from 'constructs';
 import { join } from 'path';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
-import { ChannelsResourceConfig } from '../../constants';
+import { ChannelsResourceConfig, DefaultLambdaParams } from '../../constants';
 
-interface ChannelsCognitoTriggersProps extends ChannelsResourceConfig {}
+interface ChannelsCognitoTriggersProps extends ChannelsResourceConfig {
+  defaultLambdaParams?: DefaultLambdaParams
+}
 
 const getCognitoLambdaTriggersEntryPath = (functionName: string) =>
   join(__dirname, '../../../lambdas', 'cognitoTriggers', `${functionName}.ts`);
@@ -22,14 +24,7 @@ export default class ChannelsCognitoTriggers extends Construct {
   ) {
     super(scope, id);
 
-    const { logRetention, enableUserAutoVerify, clientBaseUrl } = props;
-
-    // Default lambda parameters
-    const defaultLambdaParams = {
-      ...(logRetention ? { logRetention } : {}),
-      bundling: { minify: true },
-      runtime: Runtime.NODEJS_16_X
-    };
+    const { enableUserAutoVerify, clientBaseUrl, defaultLambdaParams } = props;
 
     // Lambda to auto verify new users, not suitable for production
     let preSignUpLambda;

--- a/cdk/lib/ChannelsStack/Constructs/ChannelsCognitoTriggers.ts
+++ b/cdk/lib/ChannelsStack/Constructs/ChannelsCognitoTriggers.ts
@@ -6,7 +6,7 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { ChannelsResourceConfig, DefaultLambdaParams } from '../../constants';
 
 interface ChannelsCognitoTriggersProps extends ChannelsResourceConfig {
-  defaultLambdaParams?: DefaultLambdaParams
+  defaultLambdaParams?: DefaultLambdaParams;
 }
 
 const getCognitoLambdaTriggersEntryPath = (functionName: string) =>

--- a/cdk/lib/ChannelsStack/cdk-channels-stack.ts
+++ b/cdk/lib/ChannelsStack/cdk-channels-stack.ts
@@ -18,6 +18,7 @@ import {
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ProjectionType } from 'aws-cdk-lib/aws-dynamodb';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 
 import {
@@ -63,8 +64,7 @@ export class ChannelsStack extends NestedStack {
       enableUserAutoVerify,
       ivsAdvancedChannelTranscodePreset,
       ivsChannelType,
-      signUpAllowedDomains,
-      logRetention
+      signUpAllowedDomains
     } = resourceConfig;
 
     // Cognito Lambda triggers
@@ -408,7 +408,7 @@ export class ChannelsStack extends NestedStack {
       `${stackNamePrefix}-CleanupUnverifiedUsers-Handler`,
       {
         ...defaultLambdaParams,
-        logRetention: 7,
+        logRetention: RetentionDays.ONE_WEEK,
         functionName: `${stackNamePrefix}-CleanupUnverifiedUsers`,
         entry: getLambdaEntryPath('cleanupUnverifiedUsers'),
         timeout: Duration.minutes(10),

--- a/cdk/lib/ChannelsStack/cdk-channels-stack.ts
+++ b/cdk/lib/ChannelsStack/cdk-channels-stack.ts
@@ -74,7 +74,7 @@ export class ChannelsStack extends NestedStack {
       ...(logRetention ? { logRetention } : {}),
       bundling: { minify: true },
       runtime: Runtime.NODEJS_18_X
-    }
+    };
 
     // Cognito Lambda triggers
     const { customMessageLambda, preAuthenticationLambda, preSignUpLambda } =

--- a/cdk/lib/Constructs/SQSLambdaTrigger.ts
+++ b/cdk/lib/Constructs/SQSLambdaTrigger.ts
@@ -7,9 +7,8 @@ import {
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { join } from 'path';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
-import { DefaultLambdaParams } from '../constants';
+import { defaultLambdaParams } from '../constants';
 
 type FunctionProps = lambda.NodejsFunctionProps & {
   entryFunctionName: string;
@@ -22,7 +21,6 @@ interface SQSLambdaTriggerProps {
   dlqHandler: FunctionProps;
   srcQueueProps?: sqs.QueueProps;
   dlqQueueProps?: sqs.QueueProps;
-  defaultLambdaParams?: DefaultLambdaParams;
 }
 
 const getLambdaEntryPath = (functionName: string) =>
@@ -68,8 +66,7 @@ export default class SQSLambdaTrigger extends Construct {
         ...dlqHandlerProps
       },
       srcQueueProps,
-      dlqQueueProps,
-      defaultLambdaParams
+      dlqQueueProps
     } = props;
     const srcId = `${name}-Src`;
     const dlqId = `${name}-Dlq`;
@@ -85,6 +82,7 @@ export default class SQSLambdaTrigger extends Construct {
       entry: srcHandlerEntry || getLambdaEntryPath(srcHandlerEntryFunctionName),
       description:
         'Triggered by Amazon SQS when new messages arrive in the queue',
+      logRetention: 7,
       ...srcHandlerProps
     });
     // Dead-letter Queue Lambda Trigger

--- a/cdk/lib/Constructs/SQSLambdaTrigger.ts
+++ b/cdk/lib/Constructs/SQSLambdaTrigger.ts
@@ -7,6 +7,7 @@ import {
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { join } from 'path';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 import { defaultLambdaParams } from '../constants';
 
@@ -82,7 +83,7 @@ export default class SQSLambdaTrigger extends Construct {
       entry: srcHandlerEntry || getLambdaEntryPath(srcHandlerEntryFunctionName),
       description:
         'Triggered by Amazon SQS when new messages arrive in the queue',
-      logRetention: 7,
+      logRetention: RetentionDays.ONE_WEEK,
       ...srcHandlerProps
     });
     // Dead-letter Queue Lambda Trigger
@@ -92,7 +93,7 @@ export default class SQSLambdaTrigger extends Construct {
       entry: dlqHandlerEntry || getLambdaEntryPath(dlqHandlerEntryFunctionName),
       description:
         'Triggered by Amazon SQS to handle message consumption failures and gracefully manage the life cycle of unconsumed messages',
-      logRetention: 14,
+      logRetention: RetentionDays.TWO_WEEKS,
       ...dlqHandlerProps
     });
 

--- a/cdk/lib/constants.ts
+++ b/cdk/lib/constants.ts
@@ -15,7 +15,7 @@ export interface UGCResourceWithChannelsConfig extends ChannelsResourceConfig {
   productApiLocale: string;
   productLinkRegionCode: string;
   enableAmazonProductStreamAction: boolean;
-}
+};
 
 export interface ChannelsResourceConfig {
   allowedOrigins: string[];
@@ -26,13 +26,13 @@ export interface ChannelsResourceConfig {
   logRetention?: logs.RetentionDays;
   minScalingCapacity: number;
   signUpAllowedDomains: string[];
-}
+};
 
 export interface DefaultLambdaParams {
   logRetention?: RetentionDays;
   bundling: BundlingOptions;
   runtime: Runtime;
-}
+};
 
 export const defaultTargetProps: Partial<elbv2.AddApplicationTargetsProps> = {
   healthCheck: { path: '/status' },

--- a/cdk/lib/constants.ts
+++ b/cdk/lib/constants.ts
@@ -1,9 +1,9 @@
 import {
   aws_elasticloadbalancingv2 as elbv2,
+  aws_lambda_nodejs as lambda,
   aws_logs as logs
 } from 'aws-cdk-lib';
 import { ChannelType, TranscodePreset } from '@aws-sdk/client-ivs';
-import { BundlingOptions } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export interface UGCResourceWithChannelsConfig extends ChannelsResourceConfig {
@@ -14,7 +14,7 @@ export interface UGCResourceWithChannelsConfig extends ChannelsResourceConfig {
   productApiLocale: string;
   productLinkRegionCode: string;
   enableAmazonProductStreamAction: boolean;
-};
+}
 
 export interface ChannelsResourceConfig {
   allowedOrigins: string[];
@@ -25,14 +25,9 @@ export interface ChannelsResourceConfig {
   logRetention?: logs.RetentionDays;
   minScalingCapacity: number;
   signUpAllowedDomains: string[];
-};
+}
 
-interface DefaultLambdaParams {
-  bundling: BundlingOptions;
-  runtime: Runtime;
-};
-
-export const defaultLambdaParams: DefaultLambdaParams = {
+export const defaultLambdaParams: Partial<lambda.NodejsFunctionProps> = {
   bundling: { minify: true },
   runtime: Runtime.NODEJS_18_X
 };

--- a/cdk/lib/constants.ts
+++ b/cdk/lib/constants.ts
@@ -4,7 +4,6 @@ import {
 } from 'aws-cdk-lib';
 import { ChannelType, TranscodePreset } from '@aws-sdk/client-ivs';
 import { BundlingOptions } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export interface UGCResourceWithChannelsConfig extends ChannelsResourceConfig {
@@ -28,10 +27,14 @@ export interface ChannelsResourceConfig {
   signUpAllowedDomains: string[];
 };
 
-export interface DefaultLambdaParams {
-  logRetention?: RetentionDays;
+interface DefaultLambdaParams {
   bundling: BundlingOptions;
   runtime: Runtime;
+};
+
+export const defaultLambdaParams: DefaultLambdaParams = {
+  bundling: { minify: true },
+  runtime: Runtime.NODEJS_18_X
 };
 
 export const defaultTargetProps: Partial<elbv2.AddApplicationTargetsProps> = {

--- a/cdk/lib/constants.ts
+++ b/cdk/lib/constants.ts
@@ -3,6 +3,9 @@ import {
   aws_logs as logs
 } from 'aws-cdk-lib';
 import { ChannelType, TranscodePreset } from '@aws-sdk/client-ivs';
+import { BundlingOptions } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export interface UGCResourceWithChannelsConfig extends ChannelsResourceConfig {
   deploySeparateContainers: boolean;
@@ -23,6 +26,12 @@ export interface ChannelsResourceConfig {
   logRetention?: logs.RetentionDays;
   minScalingCapacity: number;
   signUpAllowedDomains: string[];
+}
+
+export interface DefaultLambdaParams {
+  logRetention?: RetentionDays;
+  bundling: BundlingOptions;
+  runtime: Runtime;
 }
 
 export const defaultTargetProps: Partial<elbv2.AddApplicationTargetsProps> = {

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,10 +8,10 @@
       "name": "cdk",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.363.0",
-        "@aws-sdk/client-ivs": "^3.354.0",
-        "aws-cdk-lib": "2.45.0",
-        "cdk-ecr-deployment": "^2.5.6",
+        "@aws-sdk/client-cognito-identity-provider": "^3.582.0",
+        "@aws-sdk/client-ivs": "^3.582.0",
+        "aws-cdk-lib": "^2.142.1",
+        "cdk-ecr-deployment": "^2.5.41",
         "constructs": "^10.1.130",
         "source-map-support": "^0.5.16"
       },
@@ -19,47 +19,36 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.216.0",
-        "@aws-sdk/util-dynamodb": "^3.216.0",
-        "@types/aws-lambda": "^8.10.107",
-        "@types/node": "^18.8.5",
-        "aws-cdk": "2.45.0",
+        "@aws-sdk/client-dynamodb": "^3.582.0",
+        "@aws-sdk/util-dynamodb": "^3.582.0",
+        "@types/aws-lambda": "^8.10.138",
+        "@types/node": "^20.12.12",
+        "aws-cdk": "^2.142.1",
         "esbuild": "0.17.3",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4",
         "uuid": "^9.0.0"
       }
     },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
     },
-    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -67,20 +56,18 @@
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -89,31 +76,27 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -121,16 +104,14 @@
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "dependencies": {
-        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
@@ -138,2924 +119,616 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
-      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.363.0.tgz",
-      "integrity": "sha512-TkwUy5IJT021CQE3+mnEEnOcoxkNrIv/T0dXiYGivx+xt06PpjbxOY8S1UDa3oZ9zZ2ZR5v6v7AfcA58lwImPA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.582.0.tgz",
+      "integrity": "sha512-oJhQRcVmrkDLYOdMyOy0NL70Oij7DkKM1PEO1ZM9S5uXG1ypI/iAh7Kr1fpKPRlYjoZ9rKQkZywJnzKAdFhGIg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.363.0",
-        "@aws-sdk/credential-provider-node": "3.363.0",
-        "@aws-sdk/middleware-host-header": "3.363.0",
-        "@aws-sdk/middleware-logger": "3.363.0",
-        "@aws-sdk/middleware-recursion-detection": "3.363.0",
-        "@aws-sdk/middleware-signing": "3.363.0",
-        "@aws-sdk/middleware-user-agent": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.363.0",
-        "@aws-sdk/util-user-agent-node": "3.363.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.1",
-        "@smithy/middleware-retry": "^1.0.2",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.0.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.2",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sso": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
-      "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.363.0",
-        "@aws-sdk/middleware-logger": "3.363.0",
-        "@aws-sdk/middleware-recursion-detection": "3.363.0",
-        "@aws-sdk/middleware-user-agent": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.363.0",
-        "@aws-sdk/util-user-agent-node": "3.363.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.1",
-        "@smithy/middleware-retry": "^1.0.2",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.0.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.2",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
-      "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.363.0",
-        "@aws-sdk/middleware-logger": "3.363.0",
-        "@aws-sdk/middleware-recursion-detection": "3.363.0",
-        "@aws-sdk/middleware-user-agent": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.363.0",
-        "@aws-sdk/util-user-agent-node": "3.363.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.1",
-        "@smithy/middleware-retry": "^1.0.2",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.0.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.2",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sts": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
-      "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.363.0",
-        "@aws-sdk/middleware-host-header": "3.363.0",
-        "@aws-sdk/middleware-logger": "3.363.0",
-        "@aws-sdk/middleware-recursion-detection": "3.363.0",
-        "@aws-sdk/middleware-sdk-sts": "3.363.0",
-        "@aws-sdk/middleware-signing": "3.363.0",
-        "@aws-sdk/middleware-user-agent": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.363.0",
-        "@aws-sdk/util-user-agent-node": "3.363.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.1",
-        "@smithy/middleware-retry": "^1.0.1",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.1",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.2",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.1",
-        "@smithy/util-utf8": "^1.0.1",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
-      "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
-      "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.363.0",
-        "@aws-sdk/credential-provider-process": "3.363.0",
-        "@aws-sdk/credential-provider-sso": "3.363.0",
-        "@aws-sdk/credential-provider-web-identity": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
-      "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.363.0",
-        "@aws-sdk/credential-provider-ini": "3.363.0",
-        "@aws-sdk/credential-provider-process": "3.363.0",
-        "@aws-sdk/credential-provider-sso": "3.363.0",
-        "@aws-sdk/credential-provider-web-identity": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
-      "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
-      "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.363.0",
-        "@aws-sdk/token-providers": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
-      "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
-      "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
-      "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
-      "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
-      "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
-      "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/signature-v4": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-middleware": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
-      "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/token-providers": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
-      "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/types": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
-      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
-      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
-      "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/types": "^1.1.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
-      "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.216.0.tgz",
-      "integrity": "sha512-FRtDGPk3zSLDl8WE9S0LjIjwnQwHg40ew67+oLGDtjcf6fji/iduoNu6rW4bEVcZR3nY2IEX/vckRpSkwCJjDA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.582.0.tgz",
+      "integrity": "sha512-ZVpkq8B1Tm5BxQgyCGSVFB7tynUOcWOyfId993D/ykHqJf7cO4h4X6b1VS8ARF4QN9lAL2T3A/h+66w7oSB0TQ==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.216.0",
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/credential-provider-node": "3.216.0",
-        "@aws-sdk/fetch-http-handler": "3.215.0",
-        "@aws-sdk/hash-node": "3.215.0",
-        "@aws-sdk/invalid-dependency": "3.215.0",
-        "@aws-sdk/middleware-content-length": "3.215.0",
-        "@aws-sdk/middleware-endpoint": "3.215.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.215.0",
-        "@aws-sdk/middleware-host-header": "3.215.0",
-        "@aws-sdk/middleware-logger": "3.215.0",
-        "@aws-sdk/middleware-recursion-detection": "3.215.0",
-        "@aws-sdk/middleware-retry": "3.215.0",
-        "@aws-sdk/middleware-serde": "3.215.0",
-        "@aws-sdk/middleware-signing": "3.215.0",
-        "@aws-sdk/middleware-stack": "3.215.0",
-        "@aws-sdk/middleware-user-agent": "3.215.0",
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/node-http-handler": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/smithy-client": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/url-parser": "3.215.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-        "@aws-sdk/util-defaults-mode-node": "3.215.0",
-        "@aws-sdk/util-endpoints": "3.216.0",
-        "@aws-sdk/util-user-agent-browser": "3.215.0",
-        "@aws-sdk/util-user-agent-node": "3.215.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.215.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.0.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.215.0.tgz",
-      "integrity": "sha512-HTvL542nawhVqe0oC1AJchdcomEOmPivJEzYUT1LqiG3e8ikxMNa2KWSqqLPeKi2t0A/cfQy7wDUyg9+BZhDSQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.216.0.tgz",
-      "integrity": "sha512-9F7JLx9RXEXovg6V4ylqQtpH+sIqQBMIPIrRSGWiQu65rmQQLskRkUka94JsGsBzq1IQwrnqtsuP3Lb0XtwLRA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/fetch-http-handler": "3.215.0",
-        "@aws-sdk/hash-node": "3.215.0",
-        "@aws-sdk/invalid-dependency": "3.215.0",
-        "@aws-sdk/middleware-content-length": "3.215.0",
-        "@aws-sdk/middleware-endpoint": "3.215.0",
-        "@aws-sdk/middleware-host-header": "3.215.0",
-        "@aws-sdk/middleware-logger": "3.215.0",
-        "@aws-sdk/middleware-recursion-detection": "3.215.0",
-        "@aws-sdk/middleware-retry": "3.215.0",
-        "@aws-sdk/middleware-serde": "3.215.0",
-        "@aws-sdk/middleware-stack": "3.215.0",
-        "@aws-sdk/middleware-user-agent": "3.215.0",
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/node-http-handler": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/smithy-client": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/url-parser": "3.215.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-        "@aws-sdk/util-defaults-mode-node": "3.215.0",
-        "@aws-sdk/util-endpoints": "3.216.0",
-        "@aws-sdk/util-user-agent-browser": "3.215.0",
-        "@aws-sdk/util-user-agent-node": "3.215.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.216.0.tgz",
-      "integrity": "sha512-O8kmM86BHwiSwyNoIe+iHXuSpUE9PBWl3re8u+/igt/w5W5VmMVz+zQr7gRUDQ1FDgLWNEdAJa0r+JFx3pZdzA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/fetch-http-handler": "3.215.0",
-        "@aws-sdk/hash-node": "3.215.0",
-        "@aws-sdk/invalid-dependency": "3.215.0",
-        "@aws-sdk/middleware-content-length": "3.215.0",
-        "@aws-sdk/middleware-endpoint": "3.215.0",
-        "@aws-sdk/middleware-host-header": "3.215.0",
-        "@aws-sdk/middleware-logger": "3.215.0",
-        "@aws-sdk/middleware-recursion-detection": "3.215.0",
-        "@aws-sdk/middleware-retry": "3.215.0",
-        "@aws-sdk/middleware-serde": "3.215.0",
-        "@aws-sdk/middleware-stack": "3.215.0",
-        "@aws-sdk/middleware-user-agent": "3.215.0",
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/node-http-handler": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/smithy-client": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/url-parser": "3.215.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-        "@aws-sdk/util-defaults-mode-node": "3.215.0",
-        "@aws-sdk/util-endpoints": "3.216.0",
-        "@aws-sdk/util-user-agent-browser": "3.215.0",
-        "@aws-sdk/util-user-agent-node": "3.215.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.216.0.tgz",
-      "integrity": "sha512-8rpMZhZXh1kjsAvQ0WNBMDrnP4XneKkBQtt5XcDEmv/GpULt8jOIJnSIJQxt2gkRfd/I9MUC9C3aZNQoSMxa+g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/credential-provider-node": "3.216.0",
-        "@aws-sdk/fetch-http-handler": "3.215.0",
-        "@aws-sdk/hash-node": "3.215.0",
-        "@aws-sdk/invalid-dependency": "3.215.0",
-        "@aws-sdk/middleware-content-length": "3.215.0",
-        "@aws-sdk/middleware-endpoint": "3.215.0",
-        "@aws-sdk/middleware-host-header": "3.215.0",
-        "@aws-sdk/middleware-logger": "3.215.0",
-        "@aws-sdk/middleware-recursion-detection": "3.215.0",
-        "@aws-sdk/middleware-retry": "3.215.0",
-        "@aws-sdk/middleware-sdk-sts": "3.215.0",
-        "@aws-sdk/middleware-serde": "3.215.0",
-        "@aws-sdk/middleware-signing": "3.215.0",
-        "@aws-sdk/middleware-stack": "3.215.0",
-        "@aws-sdk/middleware-user-agent": "3.215.0",
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/node-http-handler": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/smithy-client": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/url-parser": "3.215.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-        "@aws-sdk/util-defaults-mode-node": "3.215.0",
-        "@aws-sdk/util-endpoints": "3.216.0",
-        "@aws-sdk/util-user-agent-browser": "3.215.0",
-        "@aws-sdk/util-user-agent-node": "3.215.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.215.0.tgz",
-      "integrity": "sha512-DxX4R+YYLQOtg0qfceKBrjVD4t1mQBG1eb7IVr2QSlckFCX8ztUNymFMuaSEo3938Jyy/NpgfUDpFqPDaSKnng==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.215.0.tgz",
-      "integrity": "sha512-n5G7I7Pxfsn81+tNsSOzspKp9SYai78oRfImsfFY4JLTcWutv7szMgFUbtEzBfUUINHpOxLiO2Lk5yu5K1C7IQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.215.0.tgz",
-      "integrity": "sha512-/4FUUR6u9gkNfxB6mEwBr0kk0myIkrDcXbAocWN3fPd/t7otzxpx/JqPZXgM6kcVP7M4T/QT75l1E1RRHLWCCQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/url-parser": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.216.0.tgz",
-      "integrity": "sha512-tSfrhgRO/l83Ou6WSOE4HauTLbDCOLMo/23Q6oGO8cs/d874J5rE4UM7a9OzE3QdM3eVbdAP7kXUgUS6i71cUw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.215.0",
-        "@aws-sdk/credential-provider-imds": "3.215.0",
-        "@aws-sdk/credential-provider-sso": "3.216.0",
-        "@aws-sdk/credential-provider-web-identity": "3.215.0",
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/shared-ini-file-loader": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.216.0.tgz",
-      "integrity": "sha512-Tumt53phB454DTkNB7a1tyCfrkA4JUGHzNLya14VLResGIGW5Re64atahUcO/WS7aTEs5vfAhBXO+p9o4K1rhQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.215.0",
-        "@aws-sdk/credential-provider-imds": "3.215.0",
-        "@aws-sdk/credential-provider-ini": "3.216.0",
-        "@aws-sdk/credential-provider-process": "3.215.0",
-        "@aws-sdk/credential-provider-sso": "3.216.0",
-        "@aws-sdk/credential-provider-web-identity": "3.215.0",
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/shared-ini-file-loader": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.215.0.tgz",
-      "integrity": "sha512-JNvj4L5B7W8byoFdfn/8Y4scoPiwCi+Ha/fRsFCrdSC7C+snDuxM/oQj33HI8DpKY1cjuigzEnpnxiNWaA09EA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/shared-ini-file-loader": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.216.0.tgz",
-      "integrity": "sha512-1Cag6AUPU4wkeMnZDJvcXXJgwrlrIxbTcRsresJYBFvs1vGJGcTbjtWV0K6fiBRP66GtvuOL9WzQ/eqRf2J7Ag==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.216.0",
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/shared-ini-file-loader": "3.215.0",
-        "@aws-sdk/token-providers": "3.216.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.215.0.tgz",
-      "integrity": "sha512-AWaDDEE3VU1HeLrXvyUrkQ6Wb3PQij5bvvrMil9L0da3b1yrcpoDanQQy7wBFBXcZIVmcmSFe5MMA/nyh2Le4g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.215.0.tgz",
-      "integrity": "sha512-JfZyrJOE+0ik1PumsIUZd0NfgEx4sZ43VSdPCD9GRhssRWudNsSF1B5fz3xA5v+1y5oQPjXZyaWCzKtnYruiWw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/querystring-builder": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/hash-node": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.215.0.tgz",
-      "integrity": "sha512-MkSRuZvo1RCRmI0VNEmRYCGGD/DkMd9lqnLtOyglMPnSX1mhyD4/DyXmcc3rYa7PsjDRAfykGWJRiMqpoMLjiQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.215.0.tgz",
-      "integrity": "sha512-++bK4BUQe8/CL/YcLZcQB8qPOhiXxhbuhYzfFS7PNVvW1QOLqKRZL/lKs24gzjcOmw7IhAbCybDZwvu2TM4DAg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.215.0.tgz",
-      "integrity": "sha512-zKJRb6jDLFl9nl/muSFbiQHA4uK3skinuDRcyLbpMvvzhuK/PVodv9QI1+wIUsFdXkaSxAlva1oG4bL8ZFi+sQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.215.0.tgz",
-      "integrity": "sha512-W0QXL5emcN9IXtMbnWT/abLxBFH2tGIfnre2jPNmZ9M7uVFxUwwv5OTUXxNLGNehJHKhiJPwhfQvMy20IDzVcw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/signature-v4": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/url-parser": "3.215.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.215.0.tgz",
-      "integrity": "sha512-GOqI7VwoENZwn+6tIMrrJ4SipIqL2JCh+BNvORVcy7CQxn1ViKkna7iaCx+QMjpg/kn9cR6kfY0n1FmgZR1w9A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.215.0.tgz",
-      "integrity": "sha512-0h4GGF0rV3jnY3jxmcAWsOdqHCYf25s0biSjmgTei+l/5S+geOGrovRPCNep0LLg0i9D8bkZsXISojilETbf+g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.215.0.tgz",
-      "integrity": "sha512-KQ+kiEsaluM4i6opjusUukxY78+UhfR7vzXHDkzZK/GplQ1hY0B+rwVO1eaULmlnmf3FK+Wd6lwrPV7xS2W+EA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.215.0.tgz",
-      "integrity": "sha512-I/dnUPVg2Kp3lW+MywBoPp06EOng8IfuaS9ph4bcJpQKrhNU5ekRgCHH2C4k1A6GcP8uyHxQ5TVV6j+l0QPIsA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/service-error-classification": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-middleware": "3.215.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.215.0.tgz",
-      "integrity": "sha512-wJRxoDf+2egbRgochaQL8+zzADx8FM/2W0spKNj8x+t/3iqw70QwxCfuEKW/uFQ3ph6eaIrv7gYc8RRjwhD8rg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.215.0",
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/signature-v4": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.215.0.tgz",
-      "integrity": "sha512-+uhLXdKvvQZcRRFc3UmemSr/YUHA4Jc+1YMjHxc3v8vvfztFJBb0wgBx999myOi8PmkYThlRBQDzXy9UCIhIJw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.215.0.tgz",
-      "integrity": "sha512-3BqzYqkmdPeOxjI8DVQE7Bm7J5QIvDy30abglXqrDg6npw6KonKI2Q3FIPFf+oLpZTMStwkoQOnwXHTPrSZ6Tg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/signature-v4": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-middleware": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.215.0.tgz",
-      "integrity": "sha512-rdSVL7LxRgjlvoluqwODD4ypBy2k/YVl6FrDplyCMSi8m2WHZG99FzdmR9bpnWK+0DGzYZSMRYx6ynJ9N9PsSw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.215.0.tgz",
-      "integrity": "sha512-X6GfoMNoEITTw7rGL/gWs8UZ0cmmmezvKcl+KtHsA642R05OR4mY5G7LdbWAw0bcrwKsuKOGmwUrC9lzGqbWUw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.215.0.tgz",
-      "integrity": "sha512-notckD94QwwxC0GsfpTxB7VH8SREIIlMsUSddqGtpModa0cq/wRb9rqnydZSoznbYpK1ND6h0C9hr/2PNz89zw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/shared-ini-file-loader": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.215.0.tgz",
-      "integrity": "sha512-btKWSR7m0UuWIN3p5MfSIvhqeYik7xri7U6nWuVI5GVzIYjzxEZOMvPAinDLDxL5wipodi0ZvTUNdDJdm7BcGQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/querystring-builder": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/property-provider": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.215.0.tgz",
-      "integrity": "sha512-dDPjMCCopkRURAmOJCMSlpIQ5BGWCpYj0+FIfZ5qWQs24fn1PAkQHecOiBhJO0ZSVuQy3xcIyWsAp1NE5e+7ug==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.215.0.tgz",
-      "integrity": "sha512-qp6Y6v4S534LAjadiVl9p7ErK7ImphOKq6yhFyQwxko6iITLcz8ib3yU27fs4QJcnNj5ZooqW/YlL/0EikDxCQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.215.0.tgz",
-      "integrity": "sha512-eilk8CqG37BVhQklLif00K2dOJgDzacUi8h3KVQ72ry1V3h345i4HsmaFIxvnz8XtNyDvV8qFAzeYg9n2P9RQA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.215.0.tgz",
-      "integrity": "sha512-8h/9H8dWM4fZO27UGzo8W5JXln4yJMugPyUl4qFA437gzPgNFN95+oLJWXtHMlfCHC5T/PDKetY9TarMDgBD0Q==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.215.0.tgz",
-      "integrity": "sha512-SKBvClGFGzMPsjBBKjneaUazLCNr6bSxe9eFvOr3gCwuwE2jPQwW3VE1mb62howuvm6cLthEDwLQp/FsT1gMsw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.215.0.tgz",
-      "integrity": "sha512-unzQeLOyUiYHr8WxxandHo0OaCj31gx0wpt8dn2cZcHm/MdCqHcHcsQqOVnQsWQrrxY/XZ27cPyMVQeicNKYwQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.215.0.tgz",
-      "integrity": "sha512-Rc73uUCi3eJneO25DydLTfJYamXeuKS9YIhNMTKlpvcN1UQAmAnUbAmCuEmqvkYOiGD1i4/kd8kBga708iIikQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.215.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.215.0.tgz",
-      "integrity": "sha512-PiZfCdZkPohzMPrRmJ46TPOf2Tr/dhKYdwQArRnOOIsJABUGXjlzCUE8vysDN35XZYRx5f9hd+/U7kayhniq2w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.216.0.tgz",
-      "integrity": "sha512-cEmOfG7njWl0OA5lR65Sp2SW1i8ZLjf7C95TZ1e6t2Oo5aUFeN3aKBxMOV//1yc+BNzcFBnoHP/f29GhWxUOxA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.216.0",
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/shared-ini-file-loader": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-      "integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/url-parser": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.215.0.tgz",
-      "integrity": "sha512-r/qIk3TUlV36JvoRjTErFm0LzzgNKLB1YUG8zVZCGAc2TEATi8OVEmsZvi+KfTmsbszulITJVcjZKbHLbGoUzg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.215.0.tgz",
-      "integrity": "sha512-MiNfZgB0I4dR8CBxH163W7c9KvE38sgCHNPWopMqSX5ezz7cuCPohCU0XsWd4I7K31PvzuqmKgOiKBAZraQJMA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.215.0.tgz",
-      "integrity": "sha512-mSp3R8GljQ+4UT3QMOksQk9L0cWbFLvR7bBmAlt4+GobgTjpRfzFjBP3uwrCqFa3BKDUR3FeJq3qwo+xeY1Krg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/credential-provider-imds": "3.215.0",
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/property-provider": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.216.0.tgz",
-      "integrity": "sha512-uHje4H6Qj/z/op8UZoSuvGpEZhz/r+AGY0rCihFo7XjhT4RYVxb2Eb9uHRK/IAeHU4kjHAdpQiWGMSmnT/UacA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.215.0.tgz",
-      "integrity": "sha512-DfHGlFlQCr+T/xhjS36HH8JEThDVB5lg5NZ6x4Cibhyeps9YX/4ovLAIx3B19H34sdWhZi7q6LfslCHLRu2+7Q==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.215.0.tgz",
-      "integrity": "sha512-uZz6BJWr8sJcA+onveS1lFqnbIXBHwvkyHLgCuuGhAxd5yY6YNLhpJBnhy9Fb8/aSbk6yao3qxlokqw9gthmAw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.215.0.tgz",
-      "integrity": "sha512-4lrdd1oGRwJEwfvgvg1jcJ2O0bwElsvtiqZfTRHN6MNTFUqsKl0xHlgFChQsz3Hfrc1niWtZCmbqQKGdO5ARpw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ivs": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ivs/-/client-ivs-3.354.0.tgz",
-      "integrity": "sha512-uerHeAVvKpPdUNJRMnSjexqNnPQcDeH7cN1wJS/0E2BeRSpFachAO7xIIoyqg/QsZfuSnaIMn0ZmK2P8gqO7MA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ivs/-/client-ivs-3.582.0.tgz",
+      "integrity": "sha512-3YKcppvxc76zbsOk6GOf8rP6MjXrMGMjdFtLSYfDeoSUrgj6Hg+xUuuIDNCGxtZfX33+fuKhvCNB4ImDqWA2iQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.354.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-node": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ivs/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
-      "integrity": "sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.582.0.tgz",
+      "integrity": "sha512-C6G2vNREANe5uUCYrTs8vvGhIrrS1GRoTjr0f5qmkZDuAtuBsQNoTF6Rt+0mDwXXBYW3FcNhZntaNCGVhXlugA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.354.0.tgz",
-      "integrity": "sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.582.0.tgz",
+      "integrity": "sha512-g4uiD4GUR03CqY6LwdocJxO+fHSBk/KNXBGJv1ENCcPmK3jpEI8xBggIQOQl3NWjDeP07bpIb8+UhgSoYAYtkg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.354.0.tgz",
-      "integrity": "sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.582.0.tgz",
+      "integrity": "sha512-3gaYyQkt8iTSStnjv6kJoPGDJUaPbhcgBOrXhUNbWUgAlgw7Y1aI1MYt3JqvVN4jtiCLwjuiAQATU/8elbqPdQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-node": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-sdk-sts": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+    "node_modules/@aws-sdk/core": {
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.582.0.tgz",
+      "integrity": "sha512-ofmD96IQc9g1dbyqlCyxu5fCG7kIl9p1NoN5+vGBUyLdbmPCV3Pdg99nRHYEJuv2MgGx5AUFGDPMHcqbJpnZIw==",
       "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/core": "^2.0.1",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/signature-v4": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/fast-xml-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.354.0.tgz",
-      "integrity": "sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.353.0.tgz",
-      "integrity": "sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
+      "integrity": "sha512-Jxu255j0gToMGEiqufP8ZtKI8HW90lOLjwJ3LrdlD/NLsAY0tOQf1fWc53u28hWmmNGMxmCrL2p66IOgMDhDUw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.354.0.tgz",
-      "integrity": "sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==",
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.582.0.tgz",
+      "integrity": "sha512-kGOUKw5ryPkDIYB69PjK3SicVLTbWB06ouFN2W1EvqUJpkQGPAUGzYcomKtt3mJaCTf/1kfoaHwARAl6KKSP8Q==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.1",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.354.0.tgz",
-      "integrity": "sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.582.0.tgz",
+      "integrity": "sha512-GWcjHx6ErcZAi5GZ7kItX7E6ygYmklm9tD9dbCWdsnis7IiWfYZNMXFQEwKCubUmhT61zjGZGDUiRcqVeZu1Aw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.353.0",
-        "@aws-sdk/credential-provider-imds": "3.354.0",
-        "@aws-sdk/credential-provider-process": "3.354.0",
-        "@aws-sdk/credential-provider-sso": "3.354.0",
-        "@aws-sdk/credential-provider-web-identity": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.582.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.582.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.354.0.tgz",
-      "integrity": "sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.582.0.tgz",
+      "integrity": "sha512-T8OLA/2xayRMT8z2eIZgo8tBAamTsBn7HWc8mL1a9yzv5OCPYvucNmbO915DY8u4cNbMl2dcB9frfVxIrahCXw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.353.0",
-        "@aws-sdk/credential-provider-imds": "3.354.0",
-        "@aws-sdk/credential-provider-ini": "3.354.0",
-        "@aws-sdk/credential-provider-process": "3.354.0",
-        "@aws-sdk/credential-provider-sso": "3.354.0",
-        "@aws-sdk/credential-provider-web-identity": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-http": "3.582.0",
+        "@aws-sdk/credential-provider-ini": "3.582.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.582.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.354.0.tgz",
-      "integrity": "sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.577.0.tgz",
+      "integrity": "sha512-Gin6BWtOiXxIgITrJ3Nwc+Y2P1uVT6huYR4EcbA/DJUPWyO0n9y5UFLewPvVbLkRn15JeEqErBLUrHclkiOKtw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.354.0.tgz",
-      "integrity": "sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.582.0.tgz",
+      "integrity": "sha512-PSiBX6YvJaodGSVg6dReWfeYgK5Tl4fUi0GMuD9WXo/ckfxAPdDFtIfVR6VkSPUrkZj26uw1Pwqeefp2H5phag==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/token-providers": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.582.0",
+        "@aws-sdk/token-providers": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.354.0.tgz",
-      "integrity": "sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.577.0.tgz",
+      "integrity": "sha512-ZGHGNRaCtJJmszb9UTnC7izNCtRUttdPlLdMkh41KPS32vfdrBDHs1JrpbZijItRj1xKuOXsiYSXLAaHGcLh8Q==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.577.0"
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
-      "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.572.0.tgz",
+      "integrity": "sha512-CzuRWMj/xtN9p9eP915nlPmlyniTzke732Ow/M60++gGgB3W+RtZyFftw3TEx+NzNhd1tH54dEcGiWdiNaBz3Q==",
       "dev": true,
       "dependencies": {
         "mnemonist": "0.38.3",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
-      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
-      "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.353.0.tgz",
-      "integrity": "sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/querystring-builder": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
-      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
-      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
-      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.215.0.tgz",
-      "integrity": "sha512-87cgkFo6c1KTRpEj1f4Wq+Lz6+9ZKHWb0+sfw44ki5uXOHS5etvUdLONyluI5c+OiTdqrTaVSNs3ijU2E8BMGg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.577.0.tgz",
+      "integrity": "sha512-duLI1awiBV7xyi+SQQnFy0J2s9Fhk5miHR5LsyEpk4p4M1Zi9hbBMg3wOdoxGCnNGn56PcP70isD79BfrbWwlA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/endpoint-cache": "3.208.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/endpoint-cache": "3.572.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.215.0.tgz",
-      "integrity": "sha512-DxX4R+YYLQOtg0qfceKBrjVD4t1mQBG1eb7IVr2QSlckFCX8ztUNymFMuaSEo3938Jyy/NpgfUDpFqPDaSKnng==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.215.0.tgz",
-      "integrity": "sha512-qp6Y6v4S534LAjadiVl9p7ErK7ImphOKq6yhFyQwxko6iITLcz8ib3yU27fs4QJcnNj5ZooqW/YlL/0EikDxCQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.215.0.tgz",
-      "integrity": "sha512-Rc73uUCi3eJneO25DydLTfJYamXeuKS9YIhNMTKlpvcN1UQAmAnUbAmCuEmqvkYOiGD1i4/kd8kBga708iIikQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.215.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-      "integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.215.0.tgz",
-      "integrity": "sha512-DfHGlFlQCr+T/xhjS36HH8JEThDVB5lg5NZ6x4Cibhyeps9YX/4ovLAIx3B19H34sdWhZi7q6LfslCHLRu2+7Q==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
-      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
+      "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
-      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
+      "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
       "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
-      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
+      "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.354.0.tgz",
-      "integrity": "sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/service-error-classification": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.354.0.tgz",
-      "integrity": "sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.354.0.tgz",
-      "integrity": "sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/signature-v4": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.352.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
-      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.577.0.tgz",
+      "integrity": "sha512-P55HAXgwmiHHpFx5JEPvOnAbfhN7v6sWv9PBQs+z2tC7QiBcPS0cdJR6PfV7J1n4VPK52/OnrK3l9VxdQ7Ms0g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.354.0.tgz",
-      "integrity": "sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==",
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.577.0.tgz",
+      "integrity": "sha512-4ChCFACNwzqx/xjg3zgFcW8Ali6R9C95cFECKWT/7CUM1D0MGvkclSH2cLarmHCmJgU6onKkJroFtWp0kHhgyg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.350.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
-      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.347.0",
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/querystring-builder": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.353.0.tgz",
-      "integrity": "sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
-      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.354.0.tgz",
-      "integrity": "sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.354.0.tgz",
-      "integrity": "sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==",
-      "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.347.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.354.0.tgz",
-      "integrity": "sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
+      "integrity": "sha512-0CkIZpcC3DNQJQ1hDjm2bdSy/Xjs7Ny5YvSsacasGOkNfk+FdkiQy6N67bZX3Zbc9KIx+Nz4bu3iDeNSNplnnQ==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.577.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
+      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.353.0.tgz",
-      "integrity": "sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.354.0.tgz",
-      "integrity": "sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-imds": "3.354.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.216.0.tgz",
-      "integrity": "sha512-KoTP4CPwpKnSGZGHIC8YjqF5Wk3Z8826nksYQhIN066six6mUtfyJRHkK/nwvAimoO1k54pNit38XX8T8+hexg==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.582.0.tgz",
+      "integrity": "sha512-bptFE4T3jeuVf9rVXmM1zXMpUpPmE/ubUpI3guOJNlMG5HDldlpvgYKFrUC8oYudguWpxlk6g5hU0KqC40fayA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.582.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.352.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
-      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.577.0.tgz",
+      "integrity": "sha512-FjuUz1Kdy4Zly2q/c58tpdqHd6z7iOdU/caYzoc8jwgAHBDBbIJNQLCU9hXJnPV2M8pWxQDyIZsoVwtmvErPzw==",
       "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -3069,62 +742,29 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
-      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
-      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
+      "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
       "dependencies": {
-        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.354.0.tgz",
-      "integrity": "sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.577.0.tgz",
+      "integrity": "sha512-XqvtFjbSMtycZTWVwDe8DRWovuoMbA54nhUoZwVU6rW9OSD6NZWGR512BUGHFaWzW0Wg8++Dj10FrKTG2XtqfA==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -3135,96 +775,12 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "dependencies": {
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.215.0.tgz",
-      "integrity": "sha512-RX/EkRcuDjWKP/5K6XOnbq5cPaO9KSJ5Etotn+z5sPGUJ0xmGWEyFyfXKSL51az32tHcNoGAqboBTFDISB0LyA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.215.0.tgz",
-      "integrity": "sha512-HTvL542nawhVqe0oC1AJchdcomEOmPivJEzYUT1LqiG3e8ikxMNa2KWSqqLPeKi2t0A/cfQy7wDUyg9+BZhDSQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/types": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-      "integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -3617,487 +1173,528 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
-      "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
-      "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
+      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-config-provider": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
-      "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
+      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-codec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
-      "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
-      "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-hex-encoding": "^1.0.1",
-        "tslib": "^2.5.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
-      "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
+      "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
       "dependencies": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/querystring-builder": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-base64": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
-      "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
+      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-buffer-from": "^1.0.1",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
-      "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
+      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
-      "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
+      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
       "dependencies": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.2.tgz",
-      "integrity": "sha512-F3CyXgjtDI4quGFkDmVNytt6KMwlzzeMxtopk6Edue4uKdKcMC1vUmoRS5xTbFzKDDp4XwpnEV7FshPaL3eCPw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
+      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
       "dependencies": {
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.3.tgz",
-      "integrity": "sha512-ZRsjG8adtxQ456FULPqPFmWtrW44Fq8IgdQvQB+rC2RSho3OUzS+TiEIwb5Zs6rf2IoewITKtfdtsUZcxXO0ng==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
+      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
       "dependencies": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/service-error-classification": "^1.0.2",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-middleware": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
-      "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
+      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
-      "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
+      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
-      "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
+      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
       "dependencies": {
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
-      "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
+      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
       "dependencies": {
-        "@smithy/abort-controller": "^1.0.1",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/querystring-builder": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
-      "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
+      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
+      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
-      "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
+      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-uri-escape": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
-      "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
+      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.2.tgz",
-      "integrity": "sha512-Q5CCuzYL5FGo6Rr/O+lZxXHm2hrRgbmMn8MgyjqZUWZg20COg20DuNtIbho2iht6CoB7jOpmpBqhWizLlzUZgg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
+      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "dependencies": {
+        "@smithy/types": "^3.0.0"
+      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
-      "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
+      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
-      "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
+      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^1.0.1",
-        "@smithy/is-array-buffer": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-hex-encoding": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
-        "@smithy/util-uri-escape": "^1.0.1",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
-      "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
+      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
       "dependencies": {
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-stream": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.1",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
-      "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
+      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
       "dependencies": {
-        "@smithy/querystring-parser": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
-      "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
-      "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
-      "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
-      "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
-      "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
-      "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
+      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
       "dependencies": {
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
-      "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
+      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
       "dependencies": {
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
-      "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
+      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
-      "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
+      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.3.tgz",
-      "integrity": "sha512-gYQnZDD8I2XJFspVwUISyukjPWVikTzKR0IdG8hCWYPTpeULFl1o6yzXlT5SL63TBkuEYl0R1/93cdNtMiNnoA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
+      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
       "dependencies": {
-        "@smithy/service-error-classification": "^1.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
-      "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
+      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-buffer-from": "^1.0.1",
-        "@smithy/util-hex-encoding": "^1.0.1",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
-      "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
-      "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
+      "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -4125,16 +1722,19 @@
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.108",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.108.tgz",
-      "integrity": "sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==",
+      "version": "8.10.138",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.138.tgz",
+      "integrity": "sha512-71EHMl70TPWIAsFuHd85NHq6S6T2OOjiisPTrH7RgcjzpJpPh4RQJv7PvVvIxc6PIp8CLV7F9B+TdjcAES5vcA==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-      "dev": true
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -4164,9 +1764,9 @@
       "dev": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.45.0.tgz",
-      "integrity": "sha512-AIug6Ugvtd3I0+U3gTNZtJVDhOgpGpxwWMoOQUlX6xKGwDgQxWrWdq2QWe7ZyKgCRnY9SM90fa+Yxbx+VYk9Bw==",
+      "version": "2.142.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.142.1.tgz",
+      "integrity": "sha512-1ENZ2TY5/4uoPXat7vIzZIATdFGLy0UuqFeFU0AB/YFQqfTuSgsZRKYphpOi0zhcoDQ4rc8rPr/Dud+ZxXSc9Q==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -4179,9 +1779,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.45.0.tgz",
-      "integrity": "sha512-oEeZZF8xjub9KYAB7n01A60wwQXSzNapmiih3t5uf9aEvlvqT+0as8/WrPdNIeAaf9Lhb0WQXdZ2o2DlsFHbAg==",
+      "version": "2.142.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.142.1.tgz",
+      "integrity": "sha512-xs4NRoml5/Zh30YHSk/Wwmr7VcZOZHyIInuBye3gC/BYwCh1lsUe9/ChWIeLUCRhUrELd5npyoBOJiHb3ql7Rg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -4191,17 +1791,24 @@
         "minimatch",
         "punycode",
         "semver",
-        "yaml"
+        "table",
+        "yaml",
+        "mime-types"
       ],
       "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.0",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -4216,12 +1823,49 @@
       "inBundle": true,
       "license": "Apache-2.0"
     },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.13.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
@@ -4246,37 +1890,75 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
+      "version": "4.2.11",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -4297,6 +1979,11 @@
         "node": "*"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
       "inBundle": true,
@@ -4306,6 +1993,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
@@ -4320,15 +2026,23 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.6.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4341,12 +2055,75 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
@@ -4373,9 +2150,9 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/cdk-ecr-deployment": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.6.tgz",
-      "integrity": "sha512-Vl6FksKZLC1wE/ZjHvShg4fVZqOR8x2aIUAP+M3fe1MLKQHztApi0cG4ceVYf4FLpUlYXGRjTkJR28/cWY9RnQ==",
+      "version": "2.5.41",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.41.tgz",
+      "integrity": "sha512-eOnoWJ3h/PrSVjmC1QzmfK2DyvT6xBBy3ER0MeZmqTvrI+ZkOKY2ZDwNxdE2bMHmQy5XB0pAxnOVEc+FlpQSsg==",
       "bundleDependencies": [
         "got",
         "hpagent"
@@ -4383,7 +2160,7 @@
       "dependencies": {
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.5",
-        "got": "^11.8.3",
+        "got": "^11.8.6",
         "hpagent": "^0.1.2"
       },
       "peerDependencies": {
@@ -4392,7 +2169,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@sindresorhus/is": {
-      "version": "4.3.0",
+      "version": "4.6.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4414,28 +2191,31 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/cacheable-request": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
+        "@types/keyv": "^3.1.4",
         "@types/node": "*",
-        "@types/responselike": "*"
+        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/cacheable-request/node_modules/@types/node": {
-      "version": "17.0.35",
+      "version": "20.10.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
+      "version": "4.0.4",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/keyv": {
-      "version": "3.1.3",
+      "version": "3.1.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4443,12 +2223,15 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/keyv/node_modules/@types/node": {
-      "version": "17.0.35",
+      "version": "20.10.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/responselike": {
-      "version": "1.0.0",
+      "version": "1.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4456,9 +2239,12 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/responselike/node_modules/@types/node": {
-      "version": "17.0.35",
+      "version": "20.10.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/cdk-ecr-deployment/node_modules/cacheable-lookup": {
       "version": "5.0.4",
@@ -4469,7 +2255,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/cacheable-request": {
-      "version": "7.0.2",
+      "version": "7.0.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4486,11 +2272,22 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/clone-response": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cdk-ecr-deployment/node_modules/clone-response/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/decompress-response": {
@@ -4500,17 +2297,6 @@
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cdk-ecr-deployment/node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "inBundle": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4549,7 +2335,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/got": {
-      "version": "11.8.5",
+      "version": "11.8.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4578,7 +2364,7 @@
       "license": "MIT"
     },
     "node_modules/cdk-ecr-deployment/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
@@ -4600,7 +2386,7 @@
       "license": "MIT"
     },
     "node_modules/cdk-ecr-deployment/node_modules/keyv": {
-      "version": "4.0.5",
+      "version": "4.5.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4616,11 +2402,14 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/mimic-response": {
-      "version": "1.0.1",
+      "version": "3.1.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/normalize-url": {
@@ -4676,12 +2465,20 @@
       "license": "MIT"
     },
     "node_modules/cdk-ecr-deployment/node_modules/responselike": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/cdk-ecr-deployment/node_modules/undici-types": {
+      "version": "5.26.5",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/cdk-ecr-deployment/node_modules/wrappy": {
       "version": "1.0.2",
@@ -4749,19 +2546,24 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dev": true,
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fsevents": {
@@ -4865,9 +2667,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/typescript": {
       "version": "4.8.4",
@@ -4882,11 +2684,20 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4908,26 +2719,29 @@
     }
   },
   "dependencies": {
-    "@aws-crypto/crc32": {
+    "@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
+    },
+    "@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+    },
+    "@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
+    },
+    "@aws-crypto/ie11-detection": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "requires": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
-        "@aws-crypto/util": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          }
-        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4935,34 +2749,16 @@
         }
       }
     },
-    "@aws-crypto/ie11-detection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
     "@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -4971,35 +2767,31 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -5007,18 +2799,16 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "requires": {
-        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
@@ -5026,2527 +2816,531 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
-      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.363.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.363.0.tgz",
-      "integrity": "sha512-TkwUy5IJT021CQE3+mnEEnOcoxkNrIv/T0dXiYGivx+xt06PpjbxOY8S1UDa3oZ9zZ2ZR5v6v7AfcA58lwImPA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.582.0.tgz",
+      "integrity": "sha512-oJhQRcVmrkDLYOdMyOy0NL70Oij7DkKM1PEO1ZM9S5uXG1ypI/iAh7Kr1fpKPRlYjoZ9rKQkZywJnzKAdFhGIg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.363.0",
-        "@aws-sdk/credential-provider-node": "3.363.0",
-        "@aws-sdk/middleware-host-header": "3.363.0",
-        "@aws-sdk/middleware-logger": "3.363.0",
-        "@aws-sdk/middleware-recursion-detection": "3.363.0",
-        "@aws-sdk/middleware-signing": "3.363.0",
-        "@aws-sdk/middleware-user-agent": "3.363.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.363.0",
-        "@aws-sdk/util-user-agent-node": "3.363.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.1",
-        "@smithy/middleware-retry": "^1.0.2",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.0.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.2",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-crypto/ie11-detection": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-          "requires": {
-            "@aws-crypto/ie11-detection": "^3.0.0",
-            "@aws-crypto/sha256-js": "^3.0.0",
-            "@aws-crypto/supports-web-crypto": "^3.0.0",
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-          "requires": {
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
-          "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/middleware-host-header": "3.363.0",
-            "@aws-sdk/middleware-logger": "3.363.0",
-            "@aws-sdk/middleware-recursion-detection": "3.363.0",
-            "@aws-sdk/middleware-user-agent": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@aws-sdk/util-endpoints": "3.357.0",
-            "@aws-sdk/util-user-agent-browser": "3.363.0",
-            "@aws-sdk/util-user-agent-node": "3.363.0",
-            "@smithy/config-resolver": "^1.0.1",
-            "@smithy/fetch-http-handler": "^1.0.1",
-            "@smithy/hash-node": "^1.0.1",
-            "@smithy/invalid-dependency": "^1.0.1",
-            "@smithy/middleware-content-length": "^1.0.1",
-            "@smithy/middleware-endpoint": "^1.0.1",
-            "@smithy/middleware-retry": "^1.0.2",
-            "@smithy/middleware-serde": "^1.0.1",
-            "@smithy/middleware-stack": "^1.0.1",
-            "@smithy/node-config-provider": "^1.0.1",
-            "@smithy/node-http-handler": "^1.0.2",
-            "@smithy/protocol-http": "^1.0.1",
-            "@smithy/smithy-client": "^1.0.3",
-            "@smithy/types": "^1.0.0",
-            "@smithy/url-parser": "^1.0.1",
-            "@smithy/util-base64": "^1.0.1",
-            "@smithy/util-body-length-browser": "^1.0.1",
-            "@smithy/util-body-length-node": "^1.0.1",
-            "@smithy/util-defaults-mode-browser": "^1.0.1",
-            "@smithy/util-defaults-mode-node": "^1.0.1",
-            "@smithy/util-retry": "^1.0.2",
-            "@smithy/util-utf8": "^1.0.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
-          "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/middleware-host-header": "3.363.0",
-            "@aws-sdk/middleware-logger": "3.363.0",
-            "@aws-sdk/middleware-recursion-detection": "3.363.0",
-            "@aws-sdk/middleware-user-agent": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@aws-sdk/util-endpoints": "3.357.0",
-            "@aws-sdk/util-user-agent-browser": "3.363.0",
-            "@aws-sdk/util-user-agent-node": "3.363.0",
-            "@smithy/config-resolver": "^1.0.1",
-            "@smithy/fetch-http-handler": "^1.0.1",
-            "@smithy/hash-node": "^1.0.1",
-            "@smithy/invalid-dependency": "^1.0.1",
-            "@smithy/middleware-content-length": "^1.0.1",
-            "@smithy/middleware-endpoint": "^1.0.1",
-            "@smithy/middleware-retry": "^1.0.2",
-            "@smithy/middleware-serde": "^1.0.1",
-            "@smithy/middleware-stack": "^1.0.1",
-            "@smithy/node-config-provider": "^1.0.1",
-            "@smithy/node-http-handler": "^1.0.2",
-            "@smithy/protocol-http": "^1.0.1",
-            "@smithy/smithy-client": "^1.0.3",
-            "@smithy/types": "^1.0.0",
-            "@smithy/url-parser": "^1.0.1",
-            "@smithy/util-base64": "^1.0.1",
-            "@smithy/util-body-length-browser": "^1.0.1",
-            "@smithy/util-body-length-node": "^1.0.1",
-            "@smithy/util-defaults-mode-browser": "^1.0.1",
-            "@smithy/util-defaults-mode-node": "^1.0.1",
-            "@smithy/util-retry": "^1.0.2",
-            "@smithy/util-utf8": "^1.0.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
-          "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/credential-provider-node": "3.363.0",
-            "@aws-sdk/middleware-host-header": "3.363.0",
-            "@aws-sdk/middleware-logger": "3.363.0",
-            "@aws-sdk/middleware-recursion-detection": "3.363.0",
-            "@aws-sdk/middleware-sdk-sts": "3.363.0",
-            "@aws-sdk/middleware-signing": "3.363.0",
-            "@aws-sdk/middleware-user-agent": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@aws-sdk/util-endpoints": "3.357.0",
-            "@aws-sdk/util-user-agent-browser": "3.363.0",
-            "@aws-sdk/util-user-agent-node": "3.363.0",
-            "@smithy/config-resolver": "^1.0.1",
-            "@smithy/fetch-http-handler": "^1.0.1",
-            "@smithy/hash-node": "^1.0.1",
-            "@smithy/invalid-dependency": "^1.0.1",
-            "@smithy/middleware-content-length": "^1.0.1",
-            "@smithy/middleware-endpoint": "^1.0.1",
-            "@smithy/middleware-retry": "^1.0.1",
-            "@smithy/middleware-serde": "^1.0.1",
-            "@smithy/middleware-stack": "^1.0.1",
-            "@smithy/node-config-provider": "^1.0.1",
-            "@smithy/node-http-handler": "^1.0.1",
-            "@smithy/protocol-http": "^1.1.0",
-            "@smithy/smithy-client": "^1.0.2",
-            "@smithy/types": "^1.1.0",
-            "@smithy/url-parser": "^1.0.1",
-            "@smithy/util-base64": "^1.0.1",
-            "@smithy/util-body-length-browser": "^1.0.1",
-            "@smithy/util-body-length-node": "^1.0.1",
-            "@smithy/util-defaults-mode-browser": "^1.0.1",
-            "@smithy/util-defaults-mode-node": "^1.0.1",
-            "@smithy/util-retry": "^1.0.1",
-            "@smithy/util-utf8": "^1.0.1",
-            "fast-xml-parser": "4.2.5",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
-          "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
-          "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.363.0",
-            "@aws-sdk/credential-provider-process": "3.363.0",
-            "@aws-sdk/credential-provider-sso": "3.363.0",
-            "@aws-sdk/credential-provider-web-identity": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/credential-provider-imds": "^1.0.1",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/shared-ini-file-loader": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
-          "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.363.0",
-            "@aws-sdk/credential-provider-ini": "3.363.0",
-            "@aws-sdk/credential-provider-process": "3.363.0",
-            "@aws-sdk/credential-provider-sso": "3.363.0",
-            "@aws-sdk/credential-provider-web-identity": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/credential-provider-imds": "^1.0.1",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/shared-ini-file-loader": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
-          "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/shared-ini-file-loader": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
-          "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.363.0",
-            "@aws-sdk/token-providers": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/shared-ini-file-loader": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
-          "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
-          "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/protocol-http": "^1.1.0",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
-          "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
-          "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/protocol-http": "^1.1.0",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
-          "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
-          "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/protocol-http": "^1.1.0",
-            "@smithy/signature-v4": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "@smithy/util-middleware": "^1.0.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
-          "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@aws-sdk/util-endpoints": "3.357.0",
-            "@smithy/protocol-http": "^1.1.0",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
-          "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.363.0",
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/property-provider": "^1.0.1",
-            "@smithy/shared-ini-file-loader": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.357.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
-          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.357.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
-          "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
-          "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/types": "^1.1.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.363.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
-          "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
-          "requires": {
-            "@aws-sdk/types": "3.357.0",
-            "@smithy/node-config-provider": "^1.0.1",
-            "@smithy/types": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "fast-xml-parser": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-          "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-          "requires": {
-            "strnum": "^1.0.5"
-          }
-        }
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.216.0.tgz",
-      "integrity": "sha512-FRtDGPk3zSLDl8WE9S0LjIjwnQwHg40ew67+oLGDtjcf6fji/iduoNu6rW4bEVcZR3nY2IEX/vckRpSkwCJjDA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.582.0.tgz",
+      "integrity": "sha512-ZVpkq8B1Tm5BxQgyCGSVFB7tynUOcWOyfId993D/ykHqJf7cO4h4X6b1VS8ARF4QN9lAL2T3A/h+66w7oSB0TQ==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.216.0",
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/credential-provider-node": "3.216.0",
-        "@aws-sdk/fetch-http-handler": "3.215.0",
-        "@aws-sdk/hash-node": "3.215.0",
-        "@aws-sdk/invalid-dependency": "3.215.0",
-        "@aws-sdk/middleware-content-length": "3.215.0",
-        "@aws-sdk/middleware-endpoint": "3.215.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.215.0",
-        "@aws-sdk/middleware-host-header": "3.215.0",
-        "@aws-sdk/middleware-logger": "3.215.0",
-        "@aws-sdk/middleware-recursion-detection": "3.215.0",
-        "@aws-sdk/middleware-retry": "3.215.0",
-        "@aws-sdk/middleware-serde": "3.215.0",
-        "@aws-sdk/middleware-signing": "3.215.0",
-        "@aws-sdk/middleware-stack": "3.215.0",
-        "@aws-sdk/middleware-user-agent": "3.215.0",
-        "@aws-sdk/node-config-provider": "3.215.0",
-        "@aws-sdk/node-http-handler": "3.215.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/smithy-client": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "@aws-sdk/url-parser": "3.215.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-        "@aws-sdk/util-defaults-mode-node": "3.215.0",
-        "@aws-sdk/util-endpoints": "3.216.0",
-        "@aws-sdk/util-user-agent-browser": "3.215.0",
-        "@aws-sdk/util-user-agent-node": "3.215.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.215.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.215.0.tgz",
-          "integrity": "sha512-HTvL542nawhVqe0oC1AJchdcomEOmPivJEzYUT1LqiG3e8ikxMNa2KWSqqLPeKi2t0A/cfQy7wDUyg9+BZhDSQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.216.0.tgz",
-          "integrity": "sha512-9F7JLx9RXEXovg6V4ylqQtpH+sIqQBMIPIrRSGWiQu65rmQQLskRkUka94JsGsBzq1IQwrnqtsuP3Lb0XtwLRA==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.215.0",
-            "@aws-sdk/fetch-http-handler": "3.215.0",
-            "@aws-sdk/hash-node": "3.215.0",
-            "@aws-sdk/invalid-dependency": "3.215.0",
-            "@aws-sdk/middleware-content-length": "3.215.0",
-            "@aws-sdk/middleware-endpoint": "3.215.0",
-            "@aws-sdk/middleware-host-header": "3.215.0",
-            "@aws-sdk/middleware-logger": "3.215.0",
-            "@aws-sdk/middleware-recursion-detection": "3.215.0",
-            "@aws-sdk/middleware-retry": "3.215.0",
-            "@aws-sdk/middleware-serde": "3.215.0",
-            "@aws-sdk/middleware-stack": "3.215.0",
-            "@aws-sdk/middleware-user-agent": "3.215.0",
-            "@aws-sdk/node-config-provider": "3.215.0",
-            "@aws-sdk/node-http-handler": "3.215.0",
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/smithy-client": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/url-parser": "3.215.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-            "@aws-sdk/util-defaults-mode-node": "3.215.0",
-            "@aws-sdk/util-endpoints": "3.216.0",
-            "@aws-sdk/util-user-agent-browser": "3.215.0",
-            "@aws-sdk/util-user-agent-node": "3.215.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.216.0.tgz",
-          "integrity": "sha512-O8kmM86BHwiSwyNoIe+iHXuSpUE9PBWl3re8u+/igt/w5W5VmMVz+zQr7gRUDQ1FDgLWNEdAJa0r+JFx3pZdzA==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.215.0",
-            "@aws-sdk/fetch-http-handler": "3.215.0",
-            "@aws-sdk/hash-node": "3.215.0",
-            "@aws-sdk/invalid-dependency": "3.215.0",
-            "@aws-sdk/middleware-content-length": "3.215.0",
-            "@aws-sdk/middleware-endpoint": "3.215.0",
-            "@aws-sdk/middleware-host-header": "3.215.0",
-            "@aws-sdk/middleware-logger": "3.215.0",
-            "@aws-sdk/middleware-recursion-detection": "3.215.0",
-            "@aws-sdk/middleware-retry": "3.215.0",
-            "@aws-sdk/middleware-serde": "3.215.0",
-            "@aws-sdk/middleware-stack": "3.215.0",
-            "@aws-sdk/middleware-user-agent": "3.215.0",
-            "@aws-sdk/node-config-provider": "3.215.0",
-            "@aws-sdk/node-http-handler": "3.215.0",
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/smithy-client": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/url-parser": "3.215.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-            "@aws-sdk/util-defaults-mode-node": "3.215.0",
-            "@aws-sdk/util-endpoints": "3.216.0",
-            "@aws-sdk/util-user-agent-browser": "3.215.0",
-            "@aws-sdk/util-user-agent-node": "3.215.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.216.0.tgz",
-          "integrity": "sha512-8rpMZhZXh1kjsAvQ0WNBMDrnP4XneKkBQtt5XcDEmv/GpULt8jOIJnSIJQxt2gkRfd/I9MUC9C3aZNQoSMxa+g==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.215.0",
-            "@aws-sdk/credential-provider-node": "3.216.0",
-            "@aws-sdk/fetch-http-handler": "3.215.0",
-            "@aws-sdk/hash-node": "3.215.0",
-            "@aws-sdk/invalid-dependency": "3.215.0",
-            "@aws-sdk/middleware-content-length": "3.215.0",
-            "@aws-sdk/middleware-endpoint": "3.215.0",
-            "@aws-sdk/middleware-host-header": "3.215.0",
-            "@aws-sdk/middleware-logger": "3.215.0",
-            "@aws-sdk/middleware-recursion-detection": "3.215.0",
-            "@aws-sdk/middleware-retry": "3.215.0",
-            "@aws-sdk/middleware-sdk-sts": "3.215.0",
-            "@aws-sdk/middleware-serde": "3.215.0",
-            "@aws-sdk/middleware-signing": "3.215.0",
-            "@aws-sdk/middleware-stack": "3.215.0",
-            "@aws-sdk/middleware-user-agent": "3.215.0",
-            "@aws-sdk/node-config-provider": "3.215.0",
-            "@aws-sdk/node-http-handler": "3.215.0",
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/smithy-client": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/url-parser": "3.215.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.215.0",
-            "@aws-sdk/util-defaults-mode-node": "3.215.0",
-            "@aws-sdk/util-endpoints": "3.216.0",
-            "@aws-sdk/util-user-agent-browser": "3.215.0",
-            "@aws-sdk/util-user-agent-node": "3.215.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.215.0.tgz",
-          "integrity": "sha512-DxX4R+YYLQOtg0qfceKBrjVD4t1mQBG1eb7IVr2QSlckFCX8ztUNymFMuaSEo3938Jyy/NpgfUDpFqPDaSKnng==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/signature-v4": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.215.0.tgz",
-          "integrity": "sha512-n5G7I7Pxfsn81+tNsSOzspKp9SYai78oRfImsfFY4JLTcWutv7szMgFUbtEzBfUUINHpOxLiO2Lk5yu5K1C7IQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.215.0.tgz",
-          "integrity": "sha512-/4FUUR6u9gkNfxB6mEwBr0kk0myIkrDcXbAocWN3fPd/t7otzxpx/JqPZXgM6kcVP7M4T/QT75l1E1RRHLWCCQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.215.0",
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/url-parser": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.216.0.tgz",
-          "integrity": "sha512-tSfrhgRO/l83Ou6WSOE4HauTLbDCOLMo/23Q6oGO8cs/d874J5rE4UM7a9OzE3QdM3eVbdAP7kXUgUS6i71cUw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.215.0",
-            "@aws-sdk/credential-provider-imds": "3.215.0",
-            "@aws-sdk/credential-provider-sso": "3.216.0",
-            "@aws-sdk/credential-provider-web-identity": "3.215.0",
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/shared-ini-file-loader": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.216.0.tgz",
-          "integrity": "sha512-Tumt53phB454DTkNB7a1tyCfrkA4JUGHzNLya14VLResGIGW5Re64atahUcO/WS7aTEs5vfAhBXO+p9o4K1rhQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.215.0",
-            "@aws-sdk/credential-provider-imds": "3.215.0",
-            "@aws-sdk/credential-provider-ini": "3.216.0",
-            "@aws-sdk/credential-provider-process": "3.215.0",
-            "@aws-sdk/credential-provider-sso": "3.216.0",
-            "@aws-sdk/credential-provider-web-identity": "3.215.0",
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/shared-ini-file-loader": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.215.0.tgz",
-          "integrity": "sha512-JNvj4L5B7W8byoFdfn/8Y4scoPiwCi+Ha/fRsFCrdSC7C+snDuxM/oQj33HI8DpKY1cjuigzEnpnxiNWaA09EA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/shared-ini-file-loader": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.216.0.tgz",
-          "integrity": "sha512-1Cag6AUPU4wkeMnZDJvcXXJgwrlrIxbTcRsresJYBFvs1vGJGcTbjtWV0K6fiBRP66GtvuOL9WzQ/eqRf2J7Ag==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/client-sso": "3.216.0",
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/shared-ini-file-loader": "3.215.0",
-            "@aws-sdk/token-providers": "3.216.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.215.0.tgz",
-          "integrity": "sha512-AWaDDEE3VU1HeLrXvyUrkQ6Wb3PQij5bvvrMil9L0da3b1yrcpoDanQQy7wBFBXcZIVmcmSFe5MMA/nyh2Le4g==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.215.0.tgz",
-          "integrity": "sha512-JfZyrJOE+0ik1PumsIUZd0NfgEx4sZ43VSdPCD9GRhssRWudNsSF1B5fz3xA5v+1y5oQPjXZyaWCzKtnYruiWw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/querystring-builder": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.215.0.tgz",
-          "integrity": "sha512-MkSRuZvo1RCRmI0VNEmRYCGGD/DkMd9lqnLtOyglMPnSX1mhyD4/DyXmcc3rYa7PsjDRAfykGWJRiMqpoMLjiQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.215.0.tgz",
-          "integrity": "sha512-++bK4BUQe8/CL/YcLZcQB8qPOhiXxhbuhYzfFS7PNVvW1QOLqKRZL/lKs24gzjcOmw7IhAbCybDZwvu2TM4DAg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.215.0.tgz",
-          "integrity": "sha512-zKJRb6jDLFl9nl/muSFbiQHA4uK3skinuDRcyLbpMvvzhuK/PVodv9QI1+wIUsFdXkaSxAlva1oG4bL8ZFi+sQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.215.0.tgz",
-          "integrity": "sha512-W0QXL5emcN9IXtMbnWT/abLxBFH2tGIfnre2jPNmZ9M7uVFxUwwv5OTUXxNLGNehJHKhiJPwhfQvMy20IDzVcw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.215.0",
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/signature-v4": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/url-parser": "3.215.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.215.0.tgz",
-          "integrity": "sha512-GOqI7VwoENZwn+6tIMrrJ4SipIqL2JCh+BNvORVcy7CQxn1ViKkna7iaCx+QMjpg/kn9cR6kfY0n1FmgZR1w9A==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.215.0.tgz",
-          "integrity": "sha512-0h4GGF0rV3jnY3jxmcAWsOdqHCYf25s0biSjmgTei+l/5S+geOGrovRPCNep0LLg0i9D8bkZsXISojilETbf+g==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.215.0.tgz",
-          "integrity": "sha512-KQ+kiEsaluM4i6opjusUukxY78+UhfR7vzXHDkzZK/GplQ1hY0B+rwVO1eaULmlnmf3FK+Wd6lwrPV7xS2W+EA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.215.0.tgz",
-          "integrity": "sha512-I/dnUPVg2Kp3lW+MywBoPp06EOng8IfuaS9ph4bcJpQKrhNU5ekRgCHH2C4k1A6GcP8uyHxQ5TVV6j+l0QPIsA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/service-error-classification": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-middleware": "3.215.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.215.0.tgz",
-          "integrity": "sha512-wJRxoDf+2egbRgochaQL8+zzADx8FM/2W0spKNj8x+t/3iqw70QwxCfuEKW/uFQ3ph6eaIrv7gYc8RRjwhD8rg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.215.0",
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/signature-v4": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.215.0.tgz",
-          "integrity": "sha512-+uhLXdKvvQZcRRFc3UmemSr/YUHA4Jc+1YMjHxc3v8vvfztFJBb0wgBx999myOi8PmkYThlRBQDzXy9UCIhIJw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.215.0.tgz",
-          "integrity": "sha512-3BqzYqkmdPeOxjI8DVQE7Bm7J5QIvDy30abglXqrDg6npw6KonKI2Q3FIPFf+oLpZTMStwkoQOnwXHTPrSZ6Tg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/signature-v4": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-middleware": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.215.0.tgz",
-          "integrity": "sha512-rdSVL7LxRgjlvoluqwODD4ypBy2k/YVl6FrDplyCMSi8m2WHZG99FzdmR9bpnWK+0DGzYZSMRYx6ynJ9N9PsSw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.215.0.tgz",
-          "integrity": "sha512-X6GfoMNoEITTw7rGL/gWs8UZ0cmmmezvKcl+KtHsA642R05OR4mY5G7LdbWAw0bcrwKsuKOGmwUrC9lzGqbWUw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.215.0.tgz",
-          "integrity": "sha512-notckD94QwwxC0GsfpTxB7VH8SREIIlMsUSddqGtpModa0cq/wRb9rqnydZSoznbYpK1ND6h0C9hr/2PNz89zw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/shared-ini-file-loader": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.215.0.tgz",
-          "integrity": "sha512-btKWSR7m0UuWIN3p5MfSIvhqeYik7xri7U6nWuVI5GVzIYjzxEZOMvPAinDLDxL5wipodi0ZvTUNdDJdm7BcGQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/abort-controller": "3.215.0",
-            "@aws-sdk/protocol-http": "3.215.0",
-            "@aws-sdk/querystring-builder": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.215.0.tgz",
-          "integrity": "sha512-dDPjMCCopkRURAmOJCMSlpIQ5BGWCpYj0+FIfZ5qWQs24fn1PAkQHecOiBhJO0ZSVuQy3xcIyWsAp1NE5e+7ug==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.215.0.tgz",
-          "integrity": "sha512-qp6Y6v4S534LAjadiVl9p7ErK7ImphOKq6yhFyQwxko6iITLcz8ib3yU27fs4QJcnNj5ZooqW/YlL/0EikDxCQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.215.0.tgz",
-          "integrity": "sha512-eilk8CqG37BVhQklLif00K2dOJgDzacUi8h3KVQ72ry1V3h345i4HsmaFIxvnz8XtNyDvV8qFAzeYg9n2P9RQA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.215.0.tgz",
-          "integrity": "sha512-8h/9H8dWM4fZO27UGzo8W5JXln4yJMugPyUl4qFA437gzPgNFN95+oLJWXtHMlfCHC5T/PDKetY9TarMDgBD0Q==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.215.0.tgz",
-          "integrity": "sha512-SKBvClGFGzMPsjBBKjneaUazLCNr6bSxe9eFvOr3gCwuwE2jPQwW3VE1mb62howuvm6cLthEDwLQp/FsT1gMsw==",
-          "dev": true
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.215.0.tgz",
-          "integrity": "sha512-unzQeLOyUiYHr8WxxandHo0OaCj31gx0wpt8dn2cZcHm/MdCqHcHcsQqOVnQsWQrrxY/XZ27cPyMVQeicNKYwQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.215.0.tgz",
-          "integrity": "sha512-Rc73uUCi3eJneO25DydLTfJYamXeuKS9YIhNMTKlpvcN1UQAmAnUbAmCuEmqvkYOiGD1i4/kd8kBga708iIikQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.215.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.215.0.tgz",
-          "integrity": "sha512-PiZfCdZkPohzMPrRmJ46TPOf2Tr/dhKYdwQArRnOOIsJABUGXjlzCUE8vysDN35XZYRx5f9hd+/U7kayhniq2w==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.216.0.tgz",
-          "integrity": "sha512-cEmOfG7njWl0OA5lR65Sp2SW1i8ZLjf7C95TZ1e6t2Oo5aUFeN3aKBxMOV//1yc+BNzcFBnoHP/f29GhWxUOxA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.216.0",
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/shared-ini-file-loader": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-          "integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-          "dev": true
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.215.0.tgz",
-          "integrity": "sha512-r/qIk3TUlV36JvoRjTErFm0LzzgNKLB1YUG8zVZCGAc2TEATi8OVEmsZvi+KfTmsbszulITJVcjZKbHLbGoUzg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.215.0.tgz",
-          "integrity": "sha512-MiNfZgB0I4dR8CBxH163W7c9KvE38sgCHNPWopMqSX5ezz7cuCPohCU0XsWd4I7K31PvzuqmKgOiKBAZraQJMA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.215.0.tgz",
-          "integrity": "sha512-mSp3R8GljQ+4UT3QMOksQk9L0cWbFLvR7bBmAlt4+GobgTjpRfzFjBP3uwrCqFa3BKDUR3FeJq3qwo+xeY1Krg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/config-resolver": "3.215.0",
-            "@aws-sdk/credential-provider-imds": "3.215.0",
-            "@aws-sdk/node-config-provider": "3.215.0",
-            "@aws-sdk/property-provider": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.216.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.216.0.tgz",
-          "integrity": "sha512-uHje4H6Qj/z/op8UZoSuvGpEZhz/r+AGY0rCihFo7XjhT4RYVxb2Eb9uHRK/IAeHU4kjHAdpQiWGMSmnT/UacA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.215.0.tgz",
-          "integrity": "sha512-DfHGlFlQCr+T/xhjS36HH8JEThDVB5lg5NZ6x4Cibhyeps9YX/4ovLAIx3B19H34sdWhZi7q6LfslCHLRu2+7Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.215.0.tgz",
-          "integrity": "sha512-uZz6BJWr8sJcA+onveS1lFqnbIXBHwvkyHLgCuuGhAxd5yY6YNLhpJBnhy9Fb8/aSbk6yao3qxlokqw9gthmAw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.215.0.tgz",
-          "integrity": "sha512-4lrdd1oGRwJEwfvgvg1jcJ2O0bwElsvtiqZfTRHN6MNTFUqsKl0xHlgFChQsz3Hfrc1niWtZCmbqQKGdO5ARpw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
-        }
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.577.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.0.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       }
     },
     "@aws-sdk/client-ivs": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ivs/-/client-ivs-3.354.0.tgz",
-      "integrity": "sha512-uerHeAVvKpPdUNJRMnSjexqNnPQcDeH7cN1wJS/0E2BeRSpFachAO7xIIoyqg/QsZfuSnaIMn0ZmK2P8gqO7MA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ivs/-/client-ivs-3.582.0.tgz",
+      "integrity": "sha512-3YKcppvxc76zbsOk6GOf8rP6MjXrMGMjdFtLSYfDeoSUrgj6Hg+xUuuIDNCGxtZfX33+fuKhvCNB4ImDqWA2iQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.354.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-node": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-crypto/ie11-detection": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-          "requires": {
-            "@aws-crypto/ie11-detection": "^3.0.0",
-            "@aws-crypto/sha256-js": "^3.0.0",
-            "@aws-crypto/supports-web-crypto": "^3.0.0",
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-          "requires": {
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-base64": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        }
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
-      "integrity": "sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.582.0.tgz",
+      "integrity": "sha512-C6G2vNREANe5uUCYrTs8vvGhIrrS1GRoTjr0f5qmkZDuAtuBsQNoTF6Rt+0mDwXXBYW3FcNhZntaNCGVhXlugA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-crypto/ie11-detection": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-          "requires": {
-            "@aws-crypto/ie11-detection": "^3.0.0",
-            "@aws-crypto/sha256-js": "^3.0.0",
-            "@aws-crypto/supports-web-crypto": "^3.0.0",
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-          "requires": {
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-base64": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        }
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.354.0.tgz",
-      "integrity": "sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.582.0.tgz",
+      "integrity": "sha512-g4uiD4GUR03CqY6LwdocJxO+fHSBk/KNXBGJv1ENCcPmK3jpEI8xBggIQOQl3NWjDeP07bpIb8+UhgSoYAYtkg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-crypto/ie11-detection": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-          "requires": {
-            "@aws-crypto/ie11-detection": "^3.0.0",
-            "@aws-crypto/sha256-js": "^3.0.0",
-            "@aws-crypto/supports-web-crypto": "^3.0.0",
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-          "requires": {
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-base64": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        }
+        "@aws-sdk/client-sts": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.354.0.tgz",
-      "integrity": "sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.582.0.tgz",
+      "integrity": "sha512-3gaYyQkt8iTSStnjv6kJoPGDJUaPbhcgBOrXhUNbWUgAlgw7Y1aI1MYt3JqvVN4jtiCLwjuiAQATU/8elbqPdQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-node": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-sdk-sts": "3.354.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-crypto/ie11-detection": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-          "requires": {
-            "@aws-crypto/ie11-detection": "^3.0.0",
-            "@aws-crypto/sha256-js": "^3.0.0",
-            "@aws-crypto/supports-web-crypto": "^3.0.0",
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-          "requires": {
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-base64": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "fast-xml-parser": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-          "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
-          "requires": {
-            "strnum": "^1.0.5"
-          }
-        }
+        "@aws-sdk/client-sso-oidc": "3.582.0",
+        "@aws-sdk/core": "3.582.0",
+        "@aws-sdk/credential-provider-node": "3.582.0",
+        "@aws-sdk/middleware-host-header": "3.577.0",
+        "@aws-sdk/middleware-logger": "3.577.0",
+        "@aws-sdk/middleware-recursion-detection": "3.577.0",
+        "@aws-sdk/middleware-user-agent": "3.577.0",
+        "@aws-sdk/region-config-resolver": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@aws-sdk/util-user-agent-browser": "3.577.0",
+        "@aws-sdk/util-user-agent-node": "3.577.0",
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/core": "^2.0.1",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/hash-node": "^3.0.0",
+        "@smithy/invalid-dependency": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.1",
+        "@smithy/util-defaults-mode-node": "^3.0.1",
+        "@smithy/util-endpoints": "^2.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/config-resolver": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.354.0.tgz",
-      "integrity": "sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==",
+    "@aws-sdk/core": {
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.582.0.tgz",
+      "integrity": "sha512-ofmD96IQc9g1dbyqlCyxu5fCG7kIl9p1NoN5+vGBUyLdbmPCV3Pdg99nRHYEJuv2MgGx5AUFGDPMHcqbJpnZIw==",
       "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-sdk/util-config-provider": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-          "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+        "@smithy/core": "^2.0.1",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/signature-v4": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.353.0.tgz",
-      "integrity": "sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
+      "integrity": "sha512-Jxu255j0gToMGEiqufP8ZtKI8HW90lOLjwJ3LrdlD/NLsAY0tOQf1fWc53u28hWmmNGMxmCrL2p66IOgMDhDUw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.354.0.tgz",
-      "integrity": "sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==",
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.582.0.tgz",
+      "integrity": "sha512-kGOUKw5ryPkDIYB69PjK3SicVLTbWB06ouFN2W1EvqUJpkQGPAUGzYcomKtt3mJaCTf/1kfoaHwARAl6KKSP8Q==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.1",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.354.0.tgz",
-      "integrity": "sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.582.0.tgz",
+      "integrity": "sha512-GWcjHx6ErcZAi5GZ7kItX7E6ygYmklm9tD9dbCWdsnis7IiWfYZNMXFQEwKCubUmhT61zjGZGDUiRcqVeZu1Aw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.353.0",
-        "@aws-sdk/credential-provider-imds": "3.354.0",
-        "@aws-sdk/credential-provider-process": "3.354.0",
-        "@aws-sdk/credential-provider-sso": "3.354.0",
-        "@aws-sdk/credential-provider-web-identity": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.582.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.354.0.tgz",
-      "integrity": "sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.582.0.tgz",
+      "integrity": "sha512-T8OLA/2xayRMT8z2eIZgo8tBAamTsBn7HWc8mL1a9yzv5OCPYvucNmbO915DY8u4cNbMl2dcB9frfVxIrahCXw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.353.0",
-        "@aws-sdk/credential-provider-imds": "3.354.0",
-        "@aws-sdk/credential-provider-ini": "3.354.0",
-        "@aws-sdk/credential-provider-process": "3.354.0",
-        "@aws-sdk/credential-provider-sso": "3.354.0",
-        "@aws-sdk/credential-provider-web-identity": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.577.0",
+        "@aws-sdk/credential-provider-http": "3.582.0",
+        "@aws-sdk/credential-provider-ini": "3.582.0",
+        "@aws-sdk/credential-provider-process": "3.577.0",
+        "@aws-sdk/credential-provider-sso": "3.582.0",
+        "@aws-sdk/credential-provider-web-identity": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.354.0.tgz",
-      "integrity": "sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.577.0.tgz",
+      "integrity": "sha512-Gin6BWtOiXxIgITrJ3Nwc+Y2P1uVT6huYR4EcbA/DJUPWyO0n9y5UFLewPvVbLkRn15JeEqErBLUrHclkiOKtw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.354.0.tgz",
-      "integrity": "sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.582.0.tgz",
+      "integrity": "sha512-PSiBX6YvJaodGSVg6dReWfeYgK5Tl4fUi0GMuD9WXo/ckfxAPdDFtIfVR6VkSPUrkZj26uw1Pwqeefp2H5phag==",
       "requires": {
-        "@aws-sdk/client-sso": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/token-providers": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.582.0",
+        "@aws-sdk/token-providers": "3.577.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.354.0.tgz",
-      "integrity": "sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.577.0.tgz",
+      "integrity": "sha512-ZGHGNRaCtJJmszb9UTnC7izNCtRUttdPlLdMkh41KPS32vfdrBDHs1JrpbZijItRj1xKuOXsiYSXLAaHGcLh8Q==",
       "requires": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/endpoint-cache": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
-      "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.572.0.tgz",
+      "integrity": "sha512-CzuRWMj/xtN9p9eP915nlPmlyniTzke732Ow/M60++gGgB3W+RtZyFftw3TEx+NzNhd1tH54dEcGiWdiNaBz3Q==",
       "dev": true,
       "requires": {
         "mnemonist": "0.38.3",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/eventstream-codec": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
-      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
-      "requires": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.353.0.tgz",
-      "integrity": "sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/querystring-builder": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-base64": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        }
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
-      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        }
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
-      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
-      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.215.0.tgz",
-      "integrity": "sha512-87cgkFo6c1KTRpEj1f4Wq+Lz6+9ZKHWb0+sfw44ki5uXOHS5etvUdLONyluI5c+OiTdqrTaVSNs3ijU2E8BMGg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.577.0.tgz",
+      "integrity": "sha512-duLI1awiBV7xyi+SQQnFy0J2s9Fhk5miHR5LsyEpk4p4M1Zi9hbBMg3wOdoxGCnNGn56PcP70isD79BfrbWwlA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.215.0",
-        "@aws-sdk/endpoint-cache": "3.208.0",
-        "@aws-sdk/protocol-http": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/config-resolver": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.215.0.tgz",
-          "integrity": "sha512-DxX4R+YYLQOtg0qfceKBrjVD4t1mQBG1eb7IVr2QSlckFCX8ztUNymFMuaSEo3938Jyy/NpgfUDpFqPDaSKnng==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/signature-v4": "3.215.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.215.0.tgz",
-          "integrity": "sha512-qp6Y6v4S534LAjadiVl9p7ErK7ImphOKq6yhFyQwxko6iITLcz8ib3yU27fs4QJcnNj5ZooqW/YlL/0EikDxCQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.215.0.tgz",
-          "integrity": "sha512-Rc73uUCi3eJneO25DydLTfJYamXeuKS9YIhNMTKlpvcN1UQAmAnUbAmCuEmqvkYOiGD1i4/kd8kBga708iIikQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.215.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.215.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-          "integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-          "dev": true
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.215.0.tgz",
-          "integrity": "sha512-DfHGlFlQCr+T/xhjS36HH8JEThDVB5lg5NZ6x4Cibhyeps9YX/4ovLAIx3B19H34sdWhZi7q6LfslCHLRu2+7Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/endpoint-cache": "3.572.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
-      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
+      "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
-      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
+      "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
       "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
-      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
+      "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.354.0.tgz",
-      "integrity": "sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/service-error-classification": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.354.0.tgz",
-      "integrity": "sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==",
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.354.0.tgz",
-      "integrity": "sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/signature-v4": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-      "requires": {
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.352.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
-      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.577.0.tgz",
+      "integrity": "sha512-P55HAXgwmiHHpFx5JEPvOnAbfhN7v6sWv9PBQs+z2tC7QiBcPS0cdJR6PfV7J1n4VPK52/OnrK3l9VxdQ7Ms0g==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/util-endpoints": "3.577.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.354.0.tgz",
-      "integrity": "sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==",
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.577.0.tgz",
+      "integrity": "sha512-4ChCFACNwzqx/xjg3zgFcW8Ali6R9C95cFECKWT/7CUM1D0MGvkclSH2cLarmHCmJgU6onKkJroFtWp0kHhgyg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.350.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
-      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.347.0",
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/querystring-builder": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.353.0.tgz",
-      "integrity": "sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
-      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.354.0.tgz",
-      "integrity": "sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==",
-      "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.354.0.tgz",
-      "integrity": "sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==",
-      "requires": {
-        "@aws-sdk/eventstream-codec": "3.347.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.354.0.tgz",
-      "integrity": "sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
+      "integrity": "sha512-0CkIZpcC3DNQJQ1hDjm2bdSy/Xjs7Ny5YvSsacasGOkNfk+FdkiQy6N67bZX3Zbc9KIx+Nz4bu3iDeNSNplnnQ==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/shared-ini-file-loader": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
+      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.353.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.353.0.tgz",
-      "integrity": "sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.354.0.tgz",
-      "integrity": "sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-imds": "3.354.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/property-provider": "3.353.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-dynamodb": {
-      "version": "3.216.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.216.0.tgz",
-      "integrity": "sha512-KoTP4CPwpKnSGZGHIC8YjqF5Wk3Z8826nksYQhIN066six6mUtfyJRHkK/nwvAimoO1k54pNit38XX8T8+hexg==",
+      "version": "3.582.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.582.0.tgz",
+      "integrity": "sha512-bptFE4T3jeuVf9rVXmM1zXMpUpPmE/ubUpI3guOJNlMG5HDldlpvgYKFrUC8oYudguWpxlk6g5hU0KqC40fayA==",
       "dev": true,
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.352.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
-      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.577.0.tgz",
+      "integrity": "sha512-FjuUz1Kdy4Zly2q/c58tpdqHd6z7iOdU/caYzoc8jwgAHBDBbIJNQLCU9hXJnPV2M8pWxQDyIZsoVwtmvErPzw==",
       "requires": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-endpoints": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -7557,78 +3351,26 @@
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/util-middleware": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
-      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
-      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
+      "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
       "requires": {
-        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/types": "^3.0.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.354.0.tgz",
-      "integrity": "sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==",
+      "version": "3.577.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.577.0.tgz",
+      "integrity": "sha512-XqvtFjbSMtycZTWVwDe8DRWovuoMbA54nhUoZwVU6rW9OSD6NZWGR512BUGHFaWzW0Wg8++Dj10FrKTG2XtqfA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        }
+        "@aws-sdk/types": "3.577.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -7637,45 +3379,6 @@
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "requires": {
         "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-waiter": {
-      "version": "3.215.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.215.0.tgz",
-      "integrity": "sha512-RX/EkRcuDjWKP/5K6XOnbq5cPaO9KSJ5Etotn+z5sPGUJ0xmGWEyFyfXKSL51az32tHcNoGAqboBTFDISB0LyA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/abort-controller": "3.215.0",
-        "@aws-sdk/types": "3.215.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.215.0.tgz",
-          "integrity": "sha512-HTvL542nawhVqe0oC1AJchdcomEOmPivJEzYUT1LqiG3e8ikxMNa2KWSqqLPeKi2t0A/cfQy7wDUyg9+BZhDSQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.215.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.215.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-          "integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-          "dev": true
-        }
       }
     },
     "@cspotcode/source-map-support": {
@@ -7864,387 +3567,420 @@
       }
     },
     "@smithy/abort-controller": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
-      "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/config-resolver": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
-      "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
+      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-config-provider": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "requires": {
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-retry": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
-      "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
+      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
       "requires": {
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@smithy/eventstream-codec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
-      "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
-      "requires": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-hex-encoding": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
-      "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
+      "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
       "requires": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/querystring-builder": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-base64": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/hash-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
-      "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
+      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-buffer-from": "^1.0.1",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
-      "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
+      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/is-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
-      "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
+      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
       "requires": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.2.tgz",
-      "integrity": "sha512-F3CyXgjtDI4quGFkDmVNytt6KMwlzzeMxtopk6Edue4uKdKcMC1vUmoRS5xTbFzKDDp4XwpnEV7FshPaL3eCPw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
+      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
       "requires": {
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/url-parser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.3.tgz",
-      "integrity": "sha512-ZRsjG8adtxQ456FULPqPFmWtrW44Fq8IgdQvQB+rC2RSho3OUzS+TiEIwb5Zs6rf2IoewITKtfdtsUZcxXO0ng==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
+      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
       "requires": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/service-error-classification": "^1.0.2",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-middleware": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-retry": "^3.0.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
-      "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
+      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
-      "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
+      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
       "requires": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
-      "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
+      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
       "requires": {
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/shared-ini-file-loader": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
-      "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
+      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
       "requires": {
-        "@smithy/abort-controller": "^1.0.1",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/querystring-builder": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/querystring-builder": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/property-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
-      "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
+      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
+      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
-      "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
+      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-uri-escape": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
-      "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
+      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.2.tgz",
-      "integrity": "sha512-Q5CCuzYL5FGo6Rr/O+lZxXHm2hrRgbmMn8MgyjqZUWZg20COg20DuNtIbho2iht6CoB7jOpmpBqhWizLlzUZgg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
+      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "requires": {
+        "@smithy/types": "^3.0.0"
+      }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
-      "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
+      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/signature-v4": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
-      "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
+      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
       "requires": {
-        "@smithy/eventstream-codec": "^1.0.1",
-        "@smithy/is-array-buffer": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-hex-encoding": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
-        "@smithy/util-uri-escape": "^1.0.1",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/smithy-client": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
-      "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
+      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
       "requires": {
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-stream": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^3.0.0",
+        "@smithy/middleware-stack": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-stream": "^3.0.1",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/url-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
-      "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
+      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
       "requires": {
-        "@smithy/querystring-parser": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
-      "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "requires": {
-        "@smithy/util-buffer-from": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-body-length-browser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
-      "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-body-length-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
-      "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-buffer-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
-      "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "requires": {
-        "@smithy/is-array-buffer": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-config-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
-      "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
-      "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
+      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
       "requires": {
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
-      "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
+      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
       "requires": {
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/config-resolver": "^3.0.0",
+        "@smithy/credential-provider-imds": "^3.0.0",
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/property-provider": "^3.0.0",
+        "@smithy/smithy-client": "^3.0.1",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
+      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-hex-encoding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
-      "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-middleware": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
-      "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
+      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-retry": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.3.tgz",
-      "integrity": "sha512-gYQnZDD8I2XJFspVwUISyukjPWVikTzKR0IdG8hCWYPTpeULFl1o6yzXlT5SL63TBkuEYl0R1/93cdNtMiNnoA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
+      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
       "requires": {
-        "@smithy/service-error-classification": "^1.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
-      "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
+      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
       "requires": {
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-buffer-from": "^1.0.1",
-        "@smithy/util-hex-encoding": "^1.0.1",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^3.0.1",
+        "@smithy/node-http-handler": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-uri-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
-      "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-utf8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
-      "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "requires": {
-        "@smithy/util-buffer-from": "^1.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
+      "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+      "dev": true,
+      "requires": {
+        "@smithy/abort-controller": "^3.0.0",
+        "@smithy/types": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@tsconfig/node10": {
@@ -8272,16 +4008,19 @@
       "dev": true
     },
     "@types/aws-lambda": {
-      "version": "8.10.108",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.108.tgz",
-      "integrity": "sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==",
+      "version": "8.10.138",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.138.tgz",
+      "integrity": "sha512-71EHMl70TPWIAsFuHd85NHq6S6T2OOjiisPTrH7RgcjzpJpPh4RQJv7PvVvIxc6PIp8CLV7F9B+TdjcAES5vcA==",
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-      "dev": true
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "acorn": {
       "version": "8.8.1",
@@ -8302,27 +4041,32 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.45.0.tgz",
-      "integrity": "sha512-AIug6Ugvtd3I0+U3gTNZtJVDhOgpGpxwWMoOQUlX6xKGwDgQxWrWdq2QWe7ZyKgCRnY9SM90fa+Yxbx+VYk9Bw==",
+      "version": "2.142.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.142.1.tgz",
+      "integrity": "sha512-1ENZ2TY5/4uoPXat7vIzZIATdFGLy0UuqFeFU0AB/YFQqfTuSgsZRKYphpOi0zhcoDQ4rc8rPr/Dud+ZxXSc9Q==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.45.0.tgz",
-      "integrity": "sha512-oEeZZF8xjub9KYAB7n01A60wwQXSzNapmiih3t5uf9aEvlvqT+0as8/WrPdNIeAaf9Lhb0WQXdZ2o2DlsFHbAg==",
+      "version": "2.142.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.142.1.tgz",
+      "integrity": "sha512-xs4NRoml5/Zh30YHSk/Wwmr7VcZOZHyIInuBye3gC/BYwCh1lsUe9/ChWIeLUCRhUrELd5npyoBOJiHb3ql7Rg==",
       "requires": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.0",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -8330,8 +4074,29 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "at-least-node": {
-          "version": "1.0.0",
+        "ajv": {
+          "version": "8.13.0",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.4.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
           "bundled": true
         },
         "balanced-match": {
@@ -8350,26 +4115,52 @@
           "version": "1.6.3",
           "bundled": true
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "bundled": true
+        },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "bundled": true
+        },
         "fs-extra": {
-          "version": "9.1.0",
+          "version": "11.2.0",
           "bundled": true,
           "requires": {
-            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
         },
         "graceful-fs": {
-          "version": "4.2.10",
+          "version": "4.2.11",
           "bundled": true
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.3.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
           "bundled": true
         },
         "jsonfile": {
@@ -8384,11 +4175,26 @@
           "version": "1.4.1",
           "bundled": true
         },
+        "lodash.truncate": {
+          "version": "4.4.2",
+          "bundled": true
+        },
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
           "requires": {
             "yallist": "^4.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.52.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.52.0"
           }
         },
         "minimatch": {
@@ -8399,19 +4205,66 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "2.0.2",
           "bundled": true
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.6.0",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "table": {
+          "version": "6.8.2",
+          "bundled": true,
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          }
+        },
         "universalify": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
         },
         "yallist": {
           "version": "4.0.0",
@@ -8434,18 +4287,18 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "cdk-ecr-deployment": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.6.tgz",
-      "integrity": "sha512-Vl6FksKZLC1wE/ZjHvShg4fVZqOR8x2aIUAP+M3fe1MLKQHztApi0cG4ceVYf4FLpUlYXGRjTkJR28/cWY9RnQ==",
+      "version": "2.5.41",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.41.tgz",
+      "integrity": "sha512-eOnoWJ3h/PrSVjmC1QzmfK2DyvT6xBBy3ER0MeZmqTvrI+ZkOKY2ZDwNxdE2bMHmQy5XB0pAxnOVEc+FlpQSsg==",
       "requires": {
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.5",
-        "got": "^11.8.3",
+        "got": "^11.8.6",
         "hpagent": "^0.1.2"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "4.3.0",
+          "version": "4.6.0",
           "bundled": true
         },
         "@szmarczak/http-timer": {
@@ -8456,48 +4309,57 @@
           }
         },
         "@types/cacheable-request": {
-          "version": "6.0.2",
+          "version": "6.0.3",
           "bundled": true,
           "requires": {
             "@types/http-cache-semantics": "*",
-            "@types/keyv": "*",
+            "@types/keyv": "^3.1.4",
             "@types/node": "*",
-            "@types/responselike": "*"
+            "@types/responselike": "^1.0.0"
           },
           "dependencies": {
             "@types/node": {
-              "version": "17.0.35",
-              "bundled": true
+              "version": "20.10.4",
+              "bundled": true,
+              "requires": {
+                "undici-types": "~5.26.4"
+              }
             }
           }
         },
         "@types/http-cache-semantics": {
-          "version": "4.0.1",
+          "version": "4.0.4",
           "bundled": true
         },
         "@types/keyv": {
-          "version": "3.1.3",
+          "version": "3.1.4",
           "bundled": true,
           "requires": {
             "@types/node": "*"
           },
           "dependencies": {
             "@types/node": {
-              "version": "17.0.35",
-              "bundled": true
+              "version": "20.10.4",
+              "bundled": true,
+              "requires": {
+                "undici-types": "~5.26.4"
+              }
             }
           }
         },
         "@types/responselike": {
-          "version": "1.0.0",
+          "version": "1.0.3",
           "bundled": true,
           "requires": {
             "@types/node": "*"
           },
           "dependencies": {
             "@types/node": {
-              "version": "17.0.35",
-              "bundled": true
+              "version": "20.10.4",
+              "bundled": true,
+              "requires": {
+                "undici-types": "~5.26.4"
+              }
             }
           }
         },
@@ -8506,7 +4368,7 @@
           "bundled": true
         },
         "cacheable-request": {
-          "version": "7.0.2",
+          "version": "7.0.4",
           "bundled": true,
           "requires": {
             "clone-response": "^1.0.2",
@@ -8519,10 +4381,16 @@
           }
         },
         "clone-response": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "requires": {
             "mimic-response": "^1.0.0"
+          },
+          "dependencies": {
+            "mimic-response": {
+              "version": "1.0.1",
+              "bundled": true
+            }
           }
         },
         "decompress-response": {
@@ -8530,12 +4398,6 @@
           "bundled": true,
           "requires": {
             "mimic-response": "^3.1.0"
-          },
-          "dependencies": {
-            "mimic-response": {
-              "version": "3.1.0",
-              "bundled": true
-            }
           }
         },
         "defer-to-connect": {
@@ -8557,7 +4419,7 @@
           }
         },
         "got": {
-          "version": "11.8.5",
+          "version": "11.8.6",
           "bundled": true,
           "requires": {
             "@sindresorhus/is": "^4.0.0",
@@ -8578,7 +4440,7 @@
           "bundled": true
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true
         },
         "http2-wrapper": {
@@ -8594,7 +4456,7 @@
           "bundled": true
         },
         "keyv": {
-          "version": "4.0.5",
+          "version": "4.5.4",
           "bundled": true,
           "requires": {
             "json-buffer": "3.0.1"
@@ -8605,7 +4467,7 @@
           "bundled": true
         },
         "mimic-response": {
-          "version": "1.0.1",
+          "version": "3.1.0",
           "bundled": true
         },
         "normalize-url": {
@@ -8640,11 +4502,15 @@
           "bundled": true
         },
         "responselike": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
             "lowercase-keys": "^2.0.0"
           }
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "bundled": true
         },
         "wrappy": {
           "version": "1.0.2",
@@ -8700,10 +4566,9 @@
       }
     },
     "fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dev": true,
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -8777,9 +4642,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "typescript": {
       "version": "4.8.4",
@@ -8787,11 +4652,16 @@
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -10,21 +10,21 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.216.0",
-    "@aws-sdk/util-dynamodb": "^3.216.0",
-    "@types/aws-lambda": "^8.10.107",
-    "@types/node": "^18.8.5",
-    "aws-cdk": "2.45.0",
+    "@aws-sdk/client-dynamodb": "^3.582.0",
+    "@aws-sdk/util-dynamodb": "^3.582.0",
+    "@types/aws-lambda": "^8.10.138",
+    "@types/node": "^20.12.12",
+    "aws-cdk": "^2.142.1",
     "esbuild": "0.17.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
     "uuid": "^9.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.363.0",
-    "@aws-sdk/client-ivs": "^3.354.0",
-    "aws-cdk-lib": "2.45.0",
-    "cdk-ecr-deployment": "^2.5.6",
+    "@aws-sdk/client-cognito-identity-provider": "^3.582.0",
+    "@aws-sdk/client-ivs": "^3.582.0",
+    "aws-cdk-lib": "^2.142.1",
+    "cdk-ecr-deployment": "^2.5.41",
     "constructs": "^10.1.130",
     "source-map-support": "^0.5.16"
   }

--- a/cdk/streamEventsApi/src/__tests__/postStreamEvents.test.ts
+++ b/cdk/streamEventsApi/src/__tests__/postStreamEvents.test.ts
@@ -9,7 +9,7 @@ import * as sharedHelpers from '../helpers';
 import buildServer from '../buildServer';
 import {
   SESSION_CREATED,
-  SESSION_ENDED,
+  STREAM_END,
   STREAM_HEALTH_CHANGE_EVENT_TYPE,
   UNEXPECTED_EXCEPTION
 } from '../constants';
@@ -301,9 +301,9 @@ describe('postStreamEvents', () => {
     });
   });
 
-  describe('SESSION_ENDED', () => {
+  describe('STREAM_END', () => {
     beforeAll(() => {
-      requestBody.detail.event_name = SESSION_ENDED;
+      requestBody.detail.event_name = STREAM_END;
     });
 
     it('should return a 200 status code when all dynamoDB are successful', async () => {

--- a/cdk/streamEventsApi/src/constants.ts
+++ b/cdk/streamEventsApi/src/constants.ts
@@ -3,7 +3,7 @@ export const UNEXPECTED_EXCEPTION = 'UnexpectedException';
 
 // Event names
 export const SESSION_CREATED = 'Session Created';
-export const SESSION_ENDED = 'Session Ended';
+export const STREAM_END = 'Stream End';
 export const STARVATION_START = 'Starvation Start';
 
 // Event types

--- a/cdk/streamEventsApi/src/postStreamEvents.ts
+++ b/cdk/streamEventsApi/src/postStreamEvents.ts
@@ -5,7 +5,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import {
   LIMIT_BREACH_EVENT_TYPE,
   SESSION_CREATED,
-  SESSION_ENDED,
+  STREAM_END,
   STARVATION_START,
   STREAM_HEALTH_CHANGE_EVENT_TYPE,
   UNEXPECTED_EXCEPTION
@@ -137,15 +137,15 @@ const handler = async (
       additionalAttributes.startTime = eventTime;
 
       if (
-        // Handle the case where a SESSION_CREATED event is dispatched after a SESSION_ENDED event
-        !streamEvents.find((streamEvent) => streamEvent.name === SESSION_ENDED)
+        // Handle the case where a SESSION_CREATED event is dispatched after a STREAM_END event
+        !streamEvents.find((streamEvent) => streamEvent.name === STREAM_END)
       ) {
         additionalAttributes.hasErrorEvent = false;
         additionalAttributes.isOpen = 'true';
       }
     }
 
-    if (eventName === SESSION_ENDED) {
+    if (eventName === STREAM_END) {
       additionalAttributes.endTime = eventTime;
       attributesToRemove.push('isOpen');
     }

--- a/web-ui/public/index.html
+++ b/web-ui/public/index.html
@@ -27,9 +27,9 @@
       rel="stylesheet"
     />
 
-    <script src="https://player.live-video.net/1.20.0/amazon-ivs-player.min.js"></script>
+    <script src="https://player.live-video.net/1.28.0/amazon-ivs-player.min.js"></script>
     <script
-      src="https://web-broadcast.live-video.net/1.4.0/amazon-ivs-web-broadcast.js"
+      src="https://web-broadcast.live-video.net/1.12.0/amazon-ivs-web-broadcast.js"
       defer
     ></script>
 


### PR DESCRIPTION
Updates include: 
- README: Amazon Associate link updated to `https://affiliate-program.amazon.com`
- IVS SDK scripts updated to latest versions (Player@1.28.0 & Broadcast@1.12.0)
- Fix postStreamEvents handler to update DynamoDB record based on STREAM_END event instead of SESSION_ENDED: Streams do not always get a SESSION_ENDED event. This may cause status differences between the application and IVS.
- Update Lambda default params to use NODEJS_18 instead of NODEJS_16. Refactored code so that the lambda functions can use shared constant. 
- CDK AWS dependencies upgraded to latest
